### PR TITLE
fix: fixing typos and other small doc improvements

### DIFF
--- a/docs/src/content/docs/overview.mdx
+++ b/docs/src/content/docs/overview.mdx
@@ -3,7 +3,7 @@ title: GenSX Overview
 description: GenSX overview
 ---
 
-GenSX is a simple typescript framework for building complex LLM applications. It is a workflow engine designed for building agents, chatbot APIs, and more using common patterns like RAG, and reflection.
+GenSX is a simple typescript framework for building complex LLM applications. It's a workflow engine designed for building agents, chatbot APIs, and more using common patterns like RAG and reflection.
 
 It uses `jsx` to define and orchestrate workflows with functional, reusable components:
 

--- a/docs/src/content/docs/why-jsx.mdx
+++ b/docs/src/content/docs/why-jsx.mdx
@@ -3,7 +3,7 @@ title: Why JSX?
 description: Why GenSX uses JSX for workflow composition
 ---
 
-GenSX uses JSX for workflow composition because it is a natural fit for the programming model. Most people think of react and frontend when JSX is mentioned, so the choosing it for a backend workflow orchestration framework may seem surprising.
+GenSX uses JSX for workflow composition because it's a natural fit for the programming model. Most people think of React and frontend when JSX is mentioned, so choosing it for a backend workflow orchestration framework may seem surprising.
 
 This page explains why JSX is a good fit for anyone building LLM applications, whether it be simple linear workflows or complex cyclical agents.
 
@@ -57,7 +57,7 @@ On the other hand, the same workflow with GenSX and JSX reads top to bottom like
 </HNCollector>
 ```
 
-As we'll see in the next section, trees are just another kind of graph and you can express all of the same things.
+As you'll see in the next section, trees are just another kind of graph and you can express all of the same things.
 
 ## Graphs, DAGs, and trees
 
@@ -81,7 +81,7 @@ const AgentWorkflow = () => (
 );
 ```
 
-This tree structure visually represents the workflow, and programmatic JSX and typescript allow us to express cycles through normal programming constructs. This gives us the best of both worlds:
+This tree structure visually represents the workflow, and programmatic JSX and typescript allow you to express cycles through normal programming constructs. This gives you the best of both worlds:
 
 - Visual clarity of a tree structure
 - Full expressiveness of a graph API
@@ -94,7 +94,7 @@ JSX isn't limited to static trees. It gives you a way to express dynamic, progra
 
 GenSX uses JSX to encourage a functional component model, enabling you to compose your workflows from discrete, reusable steps.
 
-Functional and reusable components can be published and shared on `npm`, and it is easy to test and evaluate them in isolation.
+Functional and reusable components can be published and shared on `npm`, and it's easy to test and evaluate them in isolation.
 
 Writing robust evals is the difference between a prototype and a high quality AI app. Usually you start with end to end evals, but as workflows grow these become expensive, take a long time to run, and it can be difficult to isolate and understand the impact of changes in your workflow.
 


### PR DESCRIPTION
A few minor changes to the docs to fix typos, make perspective consistent, and add in contractions to make the writing easier to read.