### PR TITLE
docs: Add dot background pattern to landing page

### DIFF
--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -27,3 +27,34 @@ hero:
         rel: me
 editUrl: false
 ---
+
+<style>
+{`
+  .dot-background {
+    position: fixed;
+    inset: 0;
+    z-index: -1;
+    overflow: hidden;
+  }
+
+  .dot-background-mask {
+    position: absolute;
+    inset: 0;
+    -webkit-mask-image: radial-gradient(circle at center, black 40%, transparent 70%);
+    mask-image: radial-gradient(circle at center, black 40%, transparent 70%);
+  }
+
+  .dot-pattern {
+    position: absolute;
+    inset: 0;
+    background-image: radial-gradient(circle at center, rgba(100,100,100,0.3) 1px, transparent 1px);
+    background-size: 20px 20px;
+  }
+`}
+</style>
+
+<div class="dot-background">
+  <div class="dot-background-mask">
+    <div class="dot-pattern"></div>
+  </div>
+</div>


### PR DESCRIPTION
Updated the background to have a dot pattern
<img width="1443" alt="Screenshot 2025-01-13 at 10 05 19 PM" src="https://github.com/user-attachments/assets/c89bfc7b-6fce-4d3c-a45d-59de46ebf315" />
