### PR TITLE
docs: Added secondary override to be a white background instead of transparent

### DIFF
--- a/docs/src/tailwind.css
+++ b/docs/src/tailwind.css
@@ -38,3 +38,7 @@ html {
 	--sl-color-gray-7: #f5f6f8;
 	--sl-color-black: #ffffff;
 }
+
+.secondary {
+  background-color: white;
+}


### PR DESCRIPTION
Background of buttons aren't transparent which was not ideal because of the dot grid background: 
<img width="585" alt="Screenshot 2025-01-14 at 8 14 43 AM" src="https://github.com/user-attachments/assets/c35478c0-bd9c-4a75-ab27-12b27c3de86b" />
