### PR TITLE
fix: add in missing instruction to examples

### DIFF
--- a/examples/blogWriter/README.md
+++ b/examples/blogWriter/README.md
@@ -14,6 +14,9 @@ This example demonstrates how to use GenSX to create an AI-powered blog writing 
 # Install dependencies
 pnpm install
 
+# Set your OpenAI API key
+export OPENAI_API_KEY=<your_api_key>
+
 # Run the example
 pnpm run run
 ```

--- a/examples/hackerNewsAnalyzer/README.md
+++ b/examples/hackerNewsAnalyzer/README.md
@@ -15,6 +15,9 @@ This example demonstrates how to use GenSX to create a workflow that analyzes Ha
 # Install dependencies
 pnpm install
 
+# Set your OpenAI API key
+export OPENAI_API_KEY=<your_api_key>
+
 # Run the example
 pnpm run run
 ```

--- a/examples/streaming/README.md
+++ b/examples/streaming/README.md
@@ -15,6 +15,9 @@ This example demonstrates how to use GenSX's streaming capabilities with LLM res
 # Install dependencies
 pnpm install
 
+# Set your OpenAI API key
+export OPENAI_API_KEY=<your_api_key>
+
 # Run the example
 pnpm run run
 ```


### PR DESCRIPTION
Adding in instructions to set OpenAI API Key in examples
