### PR TITLE
feat: Add checkpointing

### DIFF
--- a/examples/hackerNewsAnalyzer/hackerNewsAnalyzer.tsx
+++ b/examples/hackerNewsAnalyzer/hackerNewsAnalyzer.tsx
@@ -324,30 +324,28 @@ export const HNAnalyzerWorkflow = gsx.Component<
 >("HNAnalyzerWorkflow", ({ postCount }) => {
   return (
     <OpenAIProvider apiKey={process.env.OPENAI_API_KEY}>
-      {() => (
-        <HNCollector limit={postCount}>
-          {(stories) => (
-            <AnalyzeHNPosts stories={stories}>
-              {({ analyses }) => (
-                <TrendAnalyzer analyses={analyses}>
-                  {(report) => (
-                    <PGEditor content={report}>
-                      {(editedReport) => (
-                        <PGTweetWriter
-                          context={editedReport}
-                          prompt="Summarize the HN trends in a tweet"
-                        >
-                          {(tweet) => ({ report: editedReport, tweet })}
-                        </PGTweetWriter>
-                      )}
-                    </PGEditor>
-                  )}
-                </TrendAnalyzer>
-              )}
-            </AnalyzeHNPosts>
-          )}
-        </HNCollector>
-      )}
+      <HNCollector limit={postCount}>
+        {(stories) => (
+          <AnalyzeHNPosts stories={stories}>
+            {({ analyses }) => (
+              <TrendAnalyzer analyses={analyses}>
+                {(report) => (
+                  <PGEditor content={report}>
+                    {(editedReport) => (
+                      <PGTweetWriter
+                        context={editedReport}
+                        prompt="Summarize the HN trends in a tweet"
+                      >
+                        {(tweet) => ({ report: editedReport, tweet })}
+                      </PGTweetWriter>
+                    )}
+                  </PGEditor>
+                )}
+              </TrendAnalyzer>
+            )}
+          </AnalyzeHNPosts>
+        )}
+      </HNCollector>
     </OpenAIProvider>
   );
 });

--- a/examples/hackerNewsAnalyzer/hn.ts
+++ b/examples/hackerNewsAnalyzer/hn.ts
@@ -112,7 +112,7 @@ export async function getFullStory(id: number): Promise<HNStory | null> {
 
 export async function getTopStoryDetails(
   limit = 500,
-  batchSize = 10,
+  batchSize = 50,
 ): Promise<HNStory[]> {
   const storyIds = await getTopStories(limit);
   const stories: HNStory[] = [];
@@ -126,7 +126,7 @@ export async function getTopStoryDetails(
 
     // Small delay between batches
     if (i + batchSize < storyIds.length) {
-      await new Promise((resolve) => setTimeout(resolve, 250));
+      await new Promise((resolve) => setTimeout(resolve, 100));
     }
   }
 

--- a/packages/gensx/package.json
+++ b/packages/gensx/package.json
@@ -29,7 +29,7 @@
     "build": "vite build",
     "dev": "vite build --watch",
     "clean": "rm -rf dist",
-    "test": "vitest run checkpoint --coverage",
+    "test": "vitest run --coverage",
     "test:watch": "vitest watch",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix"

--- a/packages/gensx/package.json
+++ b/packages/gensx/package.json
@@ -29,7 +29,7 @@
     "build": "vite build",
     "dev": "vite build --watch",
     "clean": "rm -rf dist",
-    "test": "vitest run --coverage",
+    "test": "vitest run checkpoint --coverage",
     "test:watch": "vitest watch",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix"

--- a/packages/gensx/src/checkpoint.ts
+++ b/packages/gensx/src/checkpoint.ts
@@ -1,0 +1,152 @@
+// Platform-agnostic file operations
+async function writeFileSafe(path: string, data: string): Promise<void> {
+  const isNode = typeof process !== "undefined";
+
+  if (isNode) {
+    // Node.js environment
+    try {
+      const { writeFile } = await import("fs/promises");
+      await writeFile(path, data);
+    } catch (error) {
+      console.error(`[Tracker] Failed to write file:`, { path, error });
+      throw error;
+    }
+  } else {
+    // Browser environment - could implement browser-specific storage here
+    console.warn(
+      "[Tracker] File writing is not supported in browser environment",
+    );
+  }
+}
+
+// Cross-platform UUID generation
+async function generateUUID(): Promise<string> {
+  try {
+    // Try Node.js crypto first
+    const crypto = await import("node:crypto");
+    return crypto.randomUUID();
+  } catch {
+    // Fallback to browser crypto
+    if (typeof globalThis !== "undefined") {
+      return globalThis.crypto.randomUUID();
+    }
+    // Simple fallback for environments without crypto
+    return "xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx".replace(/[xy]/g, c => {
+      const r = (Math.random() * 16) | 0;
+      const v = c === "x" ? r : (r & 0x3) | 0x8;
+      return v.toString(16);
+    });
+  }
+}
+
+export interface ExecutionNode {
+  id: string;
+  componentName: string;
+  parentId?: string;
+  startTime: number;
+  endTime?: number;
+  props: Record<string, unknown>;
+  output?: unknown;
+  children: ExecutionNode[];
+  metadata?: {
+    logs?: string[];
+    tokenCounts?: {
+      input: number;
+      output: number;
+    };
+    [key: string]: unknown;
+  };
+}
+
+export interface CheckpointWriter {
+  currentNode?: ExecutionNode;
+  root: ExecutionNode;
+  addNode: (node: Partial<ExecutionNode>) => Promise<string>;
+  completeNode: (id: string, output: unknown) => Promise<void>;
+  addMetadata: (id: string, metadata: Record<string, unknown>) => Promise<void>;
+  write: () => Promise<void>;
+}
+
+export class CheckpointManager implements CheckpointWriter {
+  private nodes = new Map<string, ExecutionNode>();
+  public root: ExecutionNode;
+  public currentNode?: ExecutionNode;
+
+  constructor(private checkpointPath = "./execution.json") {
+    this.root = {
+      id: "root",
+      componentName: "Root",
+      startTime: Date.now(),
+      children: [],
+      props: {},
+    };
+    this.nodes.set("root", this.root);
+    this.currentNode = this.root;
+  }
+
+  private async updateCheckpoint() {
+    try {
+      await writeFileSafe(
+        this.checkpointPath,
+        JSON.stringify(this.root, null, 2),
+      );
+    } catch (error) {
+      console.error(`[Tracker] Failed to write checkpoint:`, { error });
+    }
+  }
+
+  async addNode(partial: Partial<ExecutionNode>): Promise<string> {
+    const parentId = this.currentNode?.id ?? "root";
+    const node: ExecutionNode = {
+      id: await generateUUID(),
+      componentName: "Unknown",
+      startTime: Date.now(),
+      children: [],
+      props: {},
+      parentId,
+      ...partial,
+    };
+
+    this.nodes.set(node.id, node);
+    const parent = this.nodes.get(parentId);
+    if (parent) {
+      parent.children.push(node);
+    }
+    this.currentNode = node;
+
+    await this.updateCheckpoint();
+    return node.id;
+  }
+
+  async completeNode(id: string, output: unknown) {
+    const node = this.nodes.get(id);
+    if (node) {
+      node.endTime = Date.now();
+      node.output = output;
+
+      if (node.parentId) {
+        const parent = this.nodes.get(node.parentId);
+
+        this.currentNode = parent;
+      } else {
+        this.currentNode = undefined;
+      }
+
+      await this.updateCheckpoint();
+    } else {
+      console.warn(`[Tracker] Attempted to complete unknown node:`, { id });
+    }
+  }
+
+  async addMetadata(id: string, metadata: Record<string, unknown>) {
+    const node = this.nodes.get(id);
+    if (node) {
+      node.metadata = { ...node.metadata, ...metadata };
+      await this.updateCheckpoint();
+    }
+  }
+
+  async write() {
+    await this.updateCheckpoint();
+  }
+}

--- a/packages/gensx/src/checkpoint.ts
+++ b/packages/gensx/src/checkpoint.ts
@@ -1,3 +1,5 @@
+import { join } from "node:path";
+
 // Cross-platform UUID generation
 async function generateUUID(): Promise<string> {
   try {
@@ -100,7 +102,10 @@ export class CheckpointManager implements CheckpointWriter {
     if (!this.root) return;
 
     try {
-      const response = await fetch("http://localhost:3000/api/execution", {
+      const baseUrl =
+        process.env.GENSX_CHECKPOINT_URL ?? "http://localhost:3000";
+      const url = join(baseUrl, "api/execution");
+      const response = await fetch(url, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
@@ -119,14 +124,14 @@ export class CheckpointManager implements CheckpointWriter {
     }
   }
 
-  async addNode(partial: Partial<ExecutionNode>, parentId?: string) {
+  async addNode(partialNode: Partial<ExecutionNode>, parentId?: string) {
     const node: ExecutionNode = {
       id: await generateUUID(),
       componentName: "Unknown",
       startTime: Date.now(),
       children: [],
       props: {},
-      ...partial,
+      ...partialNode,
     };
 
     this.nodes.set(node.id, node);

--- a/packages/gensx/src/checkpoint.ts
+++ b/packages/gensx/src/checkpoint.ts
@@ -44,14 +44,14 @@ export interface CheckpointWriter {
   completeNode: (id: string, output: unknown) => Promise<void>;
   addMetadata: (id: string, metadata: Record<string, unknown>) => Promise<void>;
   write: () => Promise<void>;
-  shouldWrite: boolean;
+  checkpointsEnabled: boolean;
 }
 
 export class CheckpointManager implements CheckpointWriter {
   private nodes = new Map<string, ExecutionNode>();
   public root: ExecutionNode;
   public currentNode?: ExecutionNode;
-  public shouldWrite: boolean;
+  public checkpointsEnabled: boolean;
 
   constructor() {
     this.root = {
@@ -67,14 +67,14 @@ export class CheckpointManager implements CheckpointWriter {
     // Set shouldWrite based on environment variable
     // Environment variables are strings, so check for common truthy values
     const checkpointsEnv = process.env.GENSX_CHECKPOINTS?.toLowerCase();
-    this.shouldWrite =
+    this.checkpointsEnabled =
       checkpointsEnv === "true" ||
       checkpointsEnv === "1" ||
       checkpointsEnv === "yes";
   }
 
   private async updateCheckpoint() {
-    if (!this.shouldWrite) {
+    if (!this.checkpointsEnabled) {
       return;
     }
 

--- a/packages/gensx/src/component.ts
+++ b/packages/gensx/src/component.ts
@@ -25,6 +25,7 @@ export function Component<P, O>(
     const { checkpointManager } = workflowContext;
 
     // Create checkpoint node for this component execution
+    // only async due to dynamic import, but otherwise non-blocking
     const nodeId = await checkpointManager.addNode({
       componentName: name,
       props: Object.fromEntries(
@@ -36,14 +37,14 @@ export function Component<P, O>(
       const result = await resolveDeep(fn(props));
 
       // Complete the checkpoint node with the result
-      await checkpointManager.completeNode(nodeId, result);
+      checkpointManager.completeNode(nodeId, result);
 
       return result;
     } catch (error) {
       // Record error in checkpoint
       if (error instanceof Error) {
-        await checkpointManager.addMetadata(nodeId, { error: error.message });
-        await checkpointManager.completeNode(nodeId, undefined);
+        checkpointManager.addMetadata(nodeId, { error: error.message });
+        checkpointManager.completeNode(nodeId, undefined);
       }
       throw error;
     }

--- a/packages/gensx/src/context.ts
+++ b/packages/gensx/src/context.ts
@@ -60,11 +60,9 @@ export class ExecutionContext {
   constructor(
     public context: WorkflowContext,
     private parent?: ExecutionContext,
-    checkpointPath = "./execution.json",
   ) {
     if (!this.context[WORKFLOW_CONTEXT_SYMBOL]) {
-      this.context[WORKFLOW_CONTEXT_SYMBOL] =
-        createWorkflowContext(checkpointPath);
+      this.context[WORKFLOW_CONTEXT_SYMBOL] = createWorkflowContext();
     }
   }
 

--- a/packages/gensx/src/context.ts
+++ b/packages/gensx/src/context.ts
@@ -1,5 +1,10 @@
 import { resolveDeep } from "./resolve";
 import { Args, Context } from "./types";
+import {
+  createWorkflowContext,
+  WORKFLOW_CONTEXT_SYMBOL,
+  WorkflowExecutionContext,
+} from "./workflow-context";
 
 type WorkflowContext = Record<symbol, unknown>;
 
@@ -55,7 +60,13 @@ export class ExecutionContext {
   constructor(
     public context: WorkflowContext,
     private parent?: ExecutionContext,
-  ) {}
+    checkpointPath = "./execution.json",
+  ) {
+    if (!this.context[WORKFLOW_CONTEXT_SYMBOL]) {
+      this.context[WORKFLOW_CONTEXT_SYMBOL] =
+        createWorkflowContext(checkpointPath);
+    }
+  }
 
   withContext(newContext: Partial<WorkflowContext>): ExecutionContext {
     if (Object.getOwnPropertySymbols(newContext).length === 0) {
@@ -79,6 +90,10 @@ export class ExecutionContext {
       return this.context[key];
     }
     return this.parent?.get(key);
+  }
+
+  getWorkflowContext(): WorkflowExecutionContext {
+    return this.get(WORKFLOW_CONTEXT_SYMBOL) as WorkflowExecutionContext;
   }
 }
 

--- a/packages/gensx/src/context.ts
+++ b/packages/gensx/src/context.ts
@@ -56,6 +56,8 @@ interface AsyncLocalStorageType<T> {
   enterWith(store: T): void;
 }
 
+export const CURRENT_NODE_SYMBOL = Symbol.for("gensx.currentNode");
+
 export class ExecutionContext {
   constructor(
     public context: WorkflowContext,
@@ -92,6 +94,14 @@ export class ExecutionContext {
 
   getWorkflowContext(): WorkflowExecutionContext {
     return this.get(WORKFLOW_CONTEXT_SYMBOL) as WorkflowExecutionContext;
+  }
+
+  getCurrentNodeId(): string | undefined {
+    return this.get(CURRENT_NODE_SYMBOL) as string | undefined;
+  }
+
+  withCurrentNode<T>(nodeId: string, fn: () => Promise<T>): Promise<T> {
+    return withContext(this.withContext({ [CURRENT_NODE_SYMBOL]: nodeId }), fn);
   }
 }
 

--- a/packages/gensx/src/resolve.ts
+++ b/packages/gensx/src/resolve.ts
@@ -55,6 +55,6 @@ export async function resolveDeep<T>(value: unknown): Promise<T> {
 export async function execute<T>(element: ExecutableValue): Promise<T> {
   const context = getCurrentContext().getWorkflowContext();
   const result = (await resolveDeep(element)) as T;
-  await context.checkpointManager.write();
+  context.checkpointManager.write();
   return result;
 }

--- a/packages/gensx/src/resolve.ts
+++ b/packages/gensx/src/resolve.ts
@@ -1,4 +1,4 @@
-import { ExecutionContext } from "./context";
+import { ExecutionContext, getCurrentContext } from "./context";
 import { isStreamable } from "./stream";
 import { ExecutableValue } from "./types";
 
@@ -53,5 +53,8 @@ export async function resolveDeep<T>(value: unknown): Promise<T> {
  * This is the main entry point for executing workflow components.
  */
 export async function execute<T>(element: ExecutableValue): Promise<T> {
-  return (await resolveDeep(element)) as T;
+  const context = getCurrentContext().getWorkflowContext();
+  const result = (await resolveDeep(element)) as T;
+  await context.checkpointManager.write();
+  return result;
 }

--- a/packages/gensx/src/workflow-context.ts
+++ b/packages/gensx/src/workflow-context.ts
@@ -9,11 +9,9 @@ export interface WorkflowExecutionContext {
   // Future: Add more workflow-level utilities here
 }
 
-export function createWorkflowContext(
-  checkpointPath: string,
-): WorkflowExecutionContext {
+export function createWorkflowContext(): WorkflowExecutionContext {
   return {
-    checkpointManager: new CheckpointManager(checkpointPath),
+    checkpointManager: new CheckpointManager(),
   };
 }
 

--- a/packages/gensx/src/workflow-context.ts
+++ b/packages/gensx/src/workflow-context.ts
@@ -1,0 +1,23 @@
+import { CheckpointManager } from "./checkpoint";
+import { getCurrentContext } from "./context";
+
+// Static symbol for workflow context
+export const WORKFLOW_CONTEXT_SYMBOL = Symbol.for("gensx.workflow");
+
+export interface WorkflowExecutionContext {
+  checkpointManager: CheckpointManager;
+  // Future: Add more workflow-level utilities here
+}
+
+export function createWorkflowContext(
+  checkpointPath: string,
+): WorkflowExecutionContext {
+  return {
+    checkpointManager: new CheckpointManager(checkpointPath),
+  };
+}
+
+export function getWorkflowContext(): WorkflowExecutionContext | undefined {
+  const context = getCurrentContext();
+  return context.getWorkflowContext();
+}

--- a/packages/gensx/tests/checkpoint.test.tsx
+++ b/packages/gensx/tests/checkpoint.test.tsx
@@ -291,6 +291,7 @@ suite("checkpoint", () => {
           children: [],
         },
       ],
+      output: { a: "a:first", b: "b:second" },
     });
   });
 

--- a/packages/gensx/tests/checkpoint.test.tsx
+++ b/packages/gensx/tests/checkpoint.test.tsx
@@ -184,6 +184,7 @@ suite("checkpoint", () => {
       );
     }
     expect(countNodes(finalCheckpoint)).toBe(101);
+    expect(finalCheckpoint.children.length).toBe(100);
   });
 
   test("handles sequential execute calls within component", async () => {
@@ -219,11 +220,6 @@ suite("checkpoint", () => {
     const finalCheckpoint = checkpoints[checkpoints.length - 1];
     expect(finalCheckpoint.componentName).toBe("ParentComponent");
 
-    // TODO: Update gsx.execute to maintain proper parent context for sequential execution.
-    // Currently each execute() call creates a new nested node instead of appearing as
-    // a sibling in the parent's children array. This creates deeper nesting than desired
-    // and makes the execution tree harder to understand.
-
     // For now, verify we have the right number of total nodes (1 parent + 3 children)
     function countNodes(node: ExecutionNode): number {
       return (
@@ -231,6 +227,7 @@ suite("checkpoint", () => {
       );
     }
     expect(countNodes(finalCheckpoint)).toBe(4);
+    expect(finalCheckpoint.children.length).toBe(3);
   });
 
   test("handles component children with object return", async () => {
@@ -277,23 +274,21 @@ suite("checkpoint", () => {
     // Get final checkpoint state
     const finalCheckpoint = checkpoints[checkpoints.length - 1];
 
-    // TODO: this is not the parenting we would expect. We need to deterministically plumb in the parent context and remove the global currentNode context.
-
     // Verify checkpoint structure
     expect(finalCheckpoint).toMatchObject({
       componentName: "ParentComponent",
       children: [
         {
           componentName: "ComponentA",
-          children: [
-            {
-              componentName: "ComponentB",
-              output: "b:second",
-              props: { value: "second" },
-            },
-          ],
+          children: [],
           output: "a:first",
           props: { value: "first" },
+        },
+        {
+          componentName: "ComponentB",
+          output: "b:second",
+          props: { value: "second" },
+          children: [],
         },
       ],
     });

--- a/packages/gensx/tests/checkpoint.test.tsx
+++ b/packages/gensx/tests/checkpoint.test.tsx
@@ -1,0 +1,364 @@
+import { setTimeout } from "timers/promises";
+
+import type { ExecutionNode } from "@/checkpoint.js";
+import type { ExecutableValue } from "@/types.js";
+
+import { afterEach, beforeEach, expect, suite, test, vi } from "vitest";
+
+import { CheckpointManager } from "@/checkpoint.js";
+import { ExecutionContext, withContext } from "@/context.js";
+import { gsx } from "@/index.js";
+import { createWorkflowContext } from "@/workflow-context.js";
+
+// Add types for fetch API
+type FetchInput = Parameters<typeof fetch>[0];
+type FetchInit = Parameters<typeof fetch>[1];
+
+/**
+ * Helper to execute a workflow with checkpoint tracking
+ * Returns both the execution result and recorded checkpoints for verification
+ */
+
+// eslint-disable-next-line @typescript-eslint/no-unnecessary-type-parameters
+async function executeWithCheckpoints<T>(
+  element: ExecutableValue,
+): Promise<{ result: T; checkpoints: ExecutionNode[] }> {
+  const checkpoints: ExecutionNode[] = [];
+
+  // Set up fetch mock to capture checkpoints
+  global.fetch = vi
+    .fn()
+    // eslint-disable-next-line @typescript-eslint/require-await
+    .mockImplementation(async (_input: FetchInput, options?: FetchInit) => {
+      if (!options?.body) throw new Error("No body provided");
+      const checkpoint = JSON.parse(options.body as string) as ExecutionNode;
+      checkpoints.push(checkpoint);
+      return new Response(null, { status: 200 });
+    });
+
+  // Create and configure workflow context
+  const checkpointManager = new CheckpointManager();
+  const workflowContext = createWorkflowContext();
+  workflowContext.checkpointManager = checkpointManager;
+  const executionContext = new ExecutionContext({});
+  const contextWithWorkflow = executionContext.withContext({
+    [Symbol.for("gensx.workflow")]: workflowContext,
+  });
+
+  // Execute with context
+  const result = await withContext(contextWithWorkflow, () =>
+    gsx.execute<T>(element),
+  );
+
+  return { result, checkpoints };
+}
+
+suite("checkpoint", () => {
+  const originalFetch = global.fetch;
+  const originalEnv = process.env.GENSX_CHECKPOINTS;
+
+  beforeEach(() => {
+    process.env.GENSX_CHECKPOINTS = "true";
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    process.env.GENSX_CHECKPOINTS = originalEnv;
+    vi.restoreAllMocks();
+  });
+
+  test("basic component test", async () => {
+    // Define a simple component that returns a string
+    const SimpleComponent = gsx.Component<{ message: string }, string>(
+      "SimpleComponent",
+      async ({ message }) => {
+        await setTimeout(0); // Add small delay like other tests
+        return `hello ${message}`;
+      },
+    );
+
+    // Execute workflow and get results
+    const { result, checkpoints } = await executeWithCheckpoints<string>(
+      <SimpleComponent message="world" />,
+    );
+
+    // Verify execution result
+    expect(result).toBe("hello world");
+
+    // Verify checkpoint calls were made
+    expect(global.fetch).toHaveBeenCalled();
+
+    // Get final checkpoint state
+    const finalCheckpoint = checkpoints[checkpoints.length - 1];
+
+    // Verify checkpoint structure
+    expect(finalCheckpoint).toMatchObject({
+      componentName: "SimpleComponent",
+      props: { message: "world" },
+      output: "hello world",
+    });
+
+    // Verify timing fields
+    expect(finalCheckpoint.startTime).toBeDefined();
+    expect(finalCheckpoint.endTime).toBeDefined();
+    expect(finalCheckpoint.startTime).toBeLessThan(finalCheckpoint.endTime!);
+  });
+
+  test("no checkpoints when disabled", async () => {
+    // Disable checkpoints
+    process.env.GENSX_CHECKPOINTS = undefined;
+
+    // Define a simple component that returns a string
+    const SimpleComponent = gsx.Component<{ message: string }, string>(
+      "SimpleComponent",
+      async ({ message }) => {
+        await setTimeout(0);
+        return `hello ${message}`;
+      },
+    );
+
+    // Execute workflow and get results
+    const { result, checkpoints } = await executeWithCheckpoints<string>(
+      <SimpleComponent message="world" />,
+    );
+
+    // Verify execution still works
+    expect(result).toBe("hello world");
+
+    // Verify no checkpoint calls were made
+    expect(global.fetch).not.toHaveBeenCalled();
+    expect(checkpoints).toHaveLength(0);
+  });
+
+  test("handles parallel execution", async () => {
+    // Define a simple component that we'll use many times
+    const SimpleComponent = gsx.Component<{ id: number }, string>(
+      "SimpleComponent",
+      async ({ id }) => {
+        await setTimeout(0); // Small delay to ensure parallel execution
+        return `component ${id}`;
+      },
+    );
+
+    // Create a component that returns an array of parallel executions
+    const ParallelComponent = gsx.Component<{}, string[]>(
+      "ParallelComponent",
+      async () => {
+        return Promise.all(
+          Array.from({ length: 100 }).map((_, i) =>
+            gsx.execute<string>(<SimpleComponent id={i} />),
+          ),
+        );
+      },
+    );
+
+    // Execute workflow and get results
+    const { result, checkpoints } = await executeWithCheckpoints<string[]>(
+      <ParallelComponent />,
+    );
+
+    // Verify execution result
+    expect(result).toHaveLength(100);
+    expect(result[0]).toBe("component 0");
+    expect(result[99]).toBe("component 99");
+
+    // Verify checkpoint behavior
+    const fetchCalls = (global.fetch as unknown as ReturnType<typeof vi.fn>)
+      .mock.calls.length;
+
+    // We expect:
+    // - Some minimum number of calls to capture the state (could be heavily batched)
+    // - Less than the theoretical maximum (303 = parent(2) + children(200) + execute calls(101))
+    // - Evidence of queueing (significantly less than theoretical maximum)
+    expect(fetchCalls).toBeGreaterThan(0); // At least some calls must happen
+    expect(fetchCalls).toBeLessThan(303); // Less than theoretical maximum
+    expect(fetchCalls).toBeLessThan(250); // Evidence of significant queueing
+
+    // Verify we have all nodes
+    const finalCheckpoint = checkpoints[checkpoints.length - 1];
+    expect(finalCheckpoint.componentName).toBe("ParallelComponent");
+
+    function countNodes(node: ExecutionNode): number {
+      return (
+        1 + node.children.reduce((sum, child) => sum + countNodes(child), 0)
+      );
+    }
+    expect(countNodes(finalCheckpoint)).toBe(101);
+  });
+
+  test("handles sequential execute calls within component", async () => {
+    // Define a simple component that we'll use multiple times
+    const SimpleComponent = gsx.Component<{ id: number }, string>(
+      "SimpleComponent",
+      async ({ id }) => {
+        await setTimeout(0);
+        return `component ${id}`;
+      },
+    );
+
+    // Create a component that makes three sequential execute calls
+    const ParentComponent = gsx.Component<{}, string>(
+      "ParentComponent",
+      async () => {
+        const first = await gsx.execute<string>(<SimpleComponent id={1} />);
+        const second = await gsx.execute<string>(<SimpleComponent id={2} />);
+        const third = await gsx.execute<string>(<SimpleComponent id={3} />);
+        return `${first}, ${second}, ${third}`;
+      },
+    );
+
+    // Execute workflow and get results
+    const { result, checkpoints } = await executeWithCheckpoints<string>(
+      <ParentComponent />,
+    );
+
+    // Verify execution result
+    expect(result).toBe("component 1, component 2, component 3");
+
+    // Get final checkpoint state
+    const finalCheckpoint = checkpoints[checkpoints.length - 1];
+    expect(finalCheckpoint.componentName).toBe("ParentComponent");
+
+    // TODO: Update gsx.execute to maintain proper parent context for sequential execution.
+    // Currently each execute() call creates a new nested node instead of appearing as
+    // a sibling in the parent's children array. This creates deeper nesting than desired
+    // and makes the execution tree harder to understand.
+
+    // For now, verify we have the right number of total nodes (1 parent + 3 children)
+    function countNodes(node: ExecutionNode): number {
+      return (
+        1 + node.children.reduce((sum, child) => sum + countNodes(child), 0)
+      );
+    }
+    expect(countNodes(finalCheckpoint)).toBe(4);
+  });
+
+  test("handles component children with object return", async () => {
+    // Define child components
+    const ComponentA = gsx.Component<{ value: string }, string>(
+      "ComponentA",
+      async ({ value }) => {
+        await setTimeout(0);
+        return `a:${value}`;
+      },
+    );
+
+    const ComponentB = gsx.Component<{ value: string }, string>(
+      "ComponentB",
+      async ({ value }) => {
+        await setTimeout(0);
+        return `b:${value}`;
+      },
+    );
+
+    // Create parent component that returns an object with multiple children
+    const ParentComponent = gsx.Component<{}, { a: string; b: string }>(
+      "ParentComponent",
+      () => {
+        return {
+          a: <ComponentA value="first" />,
+          b: <ComponentB value="second" />,
+        };
+      },
+    );
+
+    // Execute workflow and get results
+    const { result, checkpoints } = await executeWithCheckpoints<{
+      a: string;
+      b: string;
+    }>(<ParentComponent />);
+
+    // Verify execution result
+    expect(result).toEqual({
+      a: "a:first",
+      b: "b:second",
+    });
+
+    // Get final checkpoint state
+    const finalCheckpoint = checkpoints[checkpoints.length - 1];
+
+    // TODO: this is not the parenting we would expect. We need to deterministically plumb in the parent context and remove the global currentNode context.
+
+    // Verify checkpoint structure
+    expect(finalCheckpoint).toMatchObject({
+      componentName: "ParentComponent",
+      children: [
+        {
+          componentName: "ComponentA",
+          children: [
+            {
+              componentName: "ComponentB",
+              output: "b:second",
+              props: { value: "second" },
+            },
+          ],
+          output: "a:first",
+          props: { value: "first" },
+        },
+      ],
+    });
+  });
+
+  test("handles nested component hierarchy", async () => {
+    // Define components that will be nested
+    const ComponentC = gsx.Component<{ value: string }, string>(
+      "ComponentC",
+      async ({ value }) => {
+        await setTimeout(0);
+        return `c:${value}`;
+      },
+    );
+
+    const ComponentB = gsx.Component<{ value: string }, string>(
+      "ComponentB",
+      async ({ value }) => {
+        const inner = await gsx.execute<string>(
+          <ComponentC value={`${value}-inner`} />,
+        );
+        return `b:${value}(${inner})`;
+      },
+    );
+
+    const ComponentA = gsx.Component<{ value: string }, string>(
+      "ComponentA",
+      async ({ value }) => {
+        const middle = await gsx.execute<string>(
+          <ComponentB value={`${value}-middle`} />,
+        );
+        return `a:${value}(${middle})`;
+      },
+    );
+
+    // Execute workflow and get results
+    const { result, checkpoints } = await executeWithCheckpoints<string>(
+      <ComponentA value="outer" />,
+    );
+
+    // Verify execution result
+    expect(result).toBe("a:outer(b:outer-middle(c:outer-middle-inner))");
+
+    // Get final checkpoint state
+    const finalCheckpoint = checkpoints[checkpoints.length - 1];
+
+    // Verify checkpoint structure shows proper nesting
+    expect(finalCheckpoint).toMatchObject({
+      componentName: "ComponentA",
+      props: { value: "outer" },
+      output: "a:outer(b:outer-middle(c:outer-middle-inner))",
+      children: [
+        {
+          componentName: "ComponentB",
+          props: { value: "outer-middle" },
+          output: "b:outer-middle(c:outer-middle-inner)",
+          children: [
+            {
+              componentName: "ComponentC",
+              props: { value: "outer-middle-inner" },
+              output: "c:outer-middle-inner",
+            },
+          ],
+        },
+      ],
+    });
+  });
+});


### PR DESCRIPTION
Checkpoint implementation with tests. 

6/7 items for https://github.com/cortexclick/gensx/issues/136 - just need to add support for streaming components (will require some care to fork the stream and make sure we don't block - will do this separately). 

Important bits here: 
- checkpointing is hidden behind an env var `GENSX_CHECKPOINTS` and is off by default
- Care is taken to minimize chattiness with the server via a "queue". We only ever process one checkpoint at a time. Processing checkpoints is non-blocking. We drop "intermediate" checkpoints if we have a "fresh" checkpoint in the queue. There is not really a queue, nor a concept of "fresh checkpoints" - but this is the best analogy. 
- Parent ID is maintained throughout execution via context to ensure nodes are parented properly. This includes subworkflows created via gsx.execute within components. 


Fixes #137 fixes #138 fixes #139 fixes #140 fixes #141 fixes #144
