### PR TITLE
docs: adding provider docs

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
   "packages/gensx": "0.2.3",
   "packages/gensx-openai": "0.1.3",
-  "packages/create-gensx": "0.1.4"
+  "packages/create-gensx": "0.1.5"
 }

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/gensx": "0.2.2",
+  "packages/gensx": "0.2.3",
   "packages/gensx-openai": "0.1.2",
   "packages/create-gensx": "0.1.4"
 }

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
   "packages/gensx": "0.2.3",
-  "packages/gensx-openai": "0.1.2",
+  "packages/gensx-openai": "0.1.3",
   "packages/create-gensx": "0.1.4"
 }

--- a/README.md
+++ b/README.md
@@ -113,18 +113,19 @@ This repo contains a number of [examples](./examples) to help you get up and run
 
 ### Basic Examples
 
-| Example                                      | Description                                               |
-| -------------------------------------------- | --------------------------------------------------------- |
-| 📊 [Structured Outputs](./structuredOutputs) | Demonstrates using structured outputs with GenSX          |
-| 🔄 [Reflection](./reflection)                | Shows how to use a self-reflection pattern with GenSX     |
-| 🌊 [Streaming](./streaming)                  | Demonstrates how to handle streaming responses with GenSX |
+| Example                                               | Description                                           |
+| ----------------------------------------------------- | ----------------------------------------------------- |
+| 📊 [Structured Outputs](./examples/structuredOutputs) | Shows how to use structured outputs with GenSX        |
+| 🔄 [Reflection](./examples/reflection)                | Shows how to use a self-reflection pattern with GenSX |
+| 🌊 [Streaming](./examples/streaming)                  | Shows how to handle streaming responses with GenSX    |
+| 🔌 [Providers](./examples/providers)                  | Shows how to create a custom provider for GenSX       |
 
 ### Full Examples
 
-| Example                                         | Description                                                                                  |
-| ----------------------------------------------- | -------------------------------------------------------------------------------------------- |
-| 🔍 [Hacker News Analyzer](./hackerNewsAnalyzer) | Analyzes HN posts and generates summaries and trends using Paul Graham's writing style       |
-| ✍️ [Blog Writer](./blogWriter)                  | Generates blogs through an end-to-end workflow including topic research and content creation |
+| Example                                                  | Description                                                                                  |
+| -------------------------------------------------------- | -------------------------------------------------------------------------------------------- |
+| 🔍 [Hacker News Analyzer](./examples/hackerNewsAnalyzer) | Analyzes HN posts and generates summaries and trends using Paul Graham's writing style       |
+| ✍️ [Blog Writer](./examples/blogWriter)                  | Generates blogs through an end-to-end workflow including topic research and content creation |
 
 ## Working with this repo
 

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -55,10 +55,10 @@ export default defineConfig({
         //   label: "LLM patterns",
         //   autogenerate: { directory: "patterns" },
         // },
-        // {
-        //   label: "Examples",
-        //   autogenerate: { directory: "examples" },
-        // },
+        {
+          label: "Examples",
+          autogenerate: { directory: "examples" },
+        },
         {
           label: "Component reference",
           autogenerate: { directory: "component-reference" },

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -59,10 +59,10 @@ export default defineConfig({
         //   label: "Examples",
         //   autogenerate: { directory: "examples" },
         // },
-        // {
-        //   label: "Component reference",
-        //   autogenerate: { directory: "component-reference" },
-        // },
+        {
+          label: "Component reference",
+          autogenerate: { directory: "component-reference" },
+        },
       ],
     }),
     tailwind({

--- a/docs/src/content/docs/basic-concepts.mdx
+++ b/docs/src/content/docs/basic-concepts.mdx
@@ -203,3 +203,5 @@ Providers offer several benefits:
 - Provide a simpler, more focused API than raw contexts
 - Keep configuration separate from business logic
 - Enable dependency injection for testing and development
+
+For more details on providers, see the [Providers](../concepts/providers) page.

--- a/docs/src/content/docs/component-reference/openai.mdx
+++ b/docs/src/content/docs/component-reference/openai.mdx
@@ -1,14 +1,85 @@
 ---
-title: OpenAI component
+title: OpenAI components
 description: OpenAI API compatible component reference
 sidebar:
   order: 1
 ---
 
-GenSX is a simple framework for building complex generative AI and LLM workflows.
+The [@gensx/openai](https://www.npmjs.com/package/@gensx/openai) package provides OpenAI API compatible components for GenSX.
 
-It uses `jsx` to define and orchestrate workflows with functional, reusable components:
+## Installation
+
+To install the package, run the following command:
+
+```bash
+npm install @gensx/openai
+```
+
+## Supported components
+
+| <div style="width:150px">Component</div> | Description                                                                                |
+| :--------------------------------------- | :----------------------------------------------------------------------------------------- |
+| [`OpenAIProvider`](#openai-provider)     | OpenAI Provider that handles configuration and authentication for child components         |
+| [`ChatCompletion`](#chat-completion)     | Component for making chat completions with OpenAI's models (`gpt-4o`, `gpt-4o-mini`, etc.) |
+
+## Reference
+
+#### `<OpenAIProvider />`
+
+The `OpenAIProvider` component initializes and provides an OpenAI client instance to all child components. Any components that use OpenAI's API need to be wrapped in an `OpenAIProvider`.
 
 ```tsx
+import { OpenAIProvider } from "@gensx/openai";
 
+<OpenAIProvider
+  apiKey="your-api-key" // Your OpenAI API key
+  organization="org-id" // Optional: Your OpenAI organization ID
+  baseURL="https://api.openai.com/v1" // Optional: API base URL
+/>;
 ```
+
+By configuring the baseURL, you can also use the `OpenAIProvider` with other OpenAI compatible APIs like [x.AI](https://docs.x.ai/docs/overview#featured-models) and [Groq](https://console.groq.com/docs/openai).
+
+```tsx
+<OpenAIProvider
+  apiKey="your-api-key" // Your Groq API key
+  baseURL="https://api.groq.com/openai/v1"
+/>
+```
+
+##### Props
+
+The `OpenAIProvider` accepts all configuration options from the [OpenAI Node.js client library](https://github.com/openai/openai-node) including:
+
+- `apiKey` (required): Your OpenAI API key
+- `organization`: Optional organization ID
+- `baseURL`: Optional API base URL
+
+#### `<ChatCompletion />`
+
+The `ChatCompletion` component creates chat completions using OpenAI's chat models. It must be used within an `OpenAIProvider`.
+
+```tsx
+import { ChatCompletion } from "@gensx/openai";
+
+<ChatCompletion
+  model="gpt-4o"
+  messages={[
+    { role: "system", content: "You are a helpful assistant." },
+    { role: "user", content: "What's a programmable tree?" },
+  ]}
+  temperature={0.7}
+  stream={true}
+/>;
+```
+
+##### Props
+
+The `ChatCompletion` component accepts all parameters from OpenAI's [chat completion API](https://platform.openai.com/docs/api-reference/chat/create) including:
+
+- `model` (required): ID of the model to use (e.g., `"gpt-4o"`, `"gpt-4o-mini"`)
+- `messages` (required): Array of messages in the conversation
+- `temperature`: Sampling temperature (0-2)
+- `stream`: Whether to stream the response
+- `maxTokens`: Maximum number of tokens to generate
+- `responseFormat`: Format of the response (example: `{ "type": "json_object" }`)

--- a/docs/src/content/docs/concepts/providers.mdx
+++ b/docs/src/content/docs/concepts/providers.mdx
@@ -1,14 +1,96 @@
 ---
 title: Providers
-description: GenSX architecture and design goals
+description: Learn how to manage API keys and configuration dependencies in GenSX using providers
 sidebar:
   order: 3
 ---
 
-GenSX is a simple framework for building complex generative AI and LLM workflows.
+Providers are a specialized use of [contexts](../contexts) that focus on managing configuration and dependencies for your workflow. They're built using the context system described above, but provide a more focused API for configuration management.
 
-It uses `jsx` to define and orchestrate workflows with functional, reusable components:
+The main provider available today is the `OpenAIProvider`, which manages your OpenAI API key:
 
 ```tsx
+const result = await gsx.execute(
+  <OpenAIProvider apiKey={process.env.OPENAI_API_KEY}>
+    <ChatCompletion
+      model="gpt-4o-mini"
+      messages={[{ role: "user", content: "Hello!" }]}
+    />
+  </OpenAIProvider>,
+);
+```
 
+Providers offer several benefits:
+
+- Manage complex configuration like API clients and settings
+- Provide a simpler, more focused API than raw contexts
+- Keep configuration separate from business logic
+- Enable dependency injection for testing and development
+
+## Creating a Provider
+
+If you want to use a provide that isn't available out of the box, you can easily create your own. The example below shows how to create a provider for the [Firecrawl](https://www.firecrawl.dev/) API.
+
+Start by importing `gsx` and the package you want to use:
+
+```tsx
+import { gsx } from "gensx";
+import FirecrawlApp, { FirecrawlAppConfig } from "@mendable/firecrawl-js";
+```
+
+Next, create a context and then the provider:
+
+```tsx
+// Create a context
+export const FirecrawlContext = gsx.createContext<{
+  client?: FirecrawlApp;
+}>({});
+
+// Create the provider
+export const FirecrawlProvider = gsx.Component<FirecrawlAppConfig, never>(
+  "FirecrawlProvider",
+  (args: FirecrawlAppConfig) => {
+    const client = new FirecrawlApp({
+      apiKey: args.apiKey,
+    });
+    return <FirecrawlContext.Provider value={{ client }} />;
+  },
+);
+```
+
+Finally, you can build components that use the provider.
+
+```tsx
+export const ScrapePage = gsx.Component<ScrapePageProps, string>(
+  "ScrapePage",
+  async ({ url }) => {
+    const context = gsx.useContext(FirecrawlContext);
+
+    if (!context.client) {
+      throw new Error(
+        "Firecrawl client not found. Please wrap your component with FirecrawlProvider.",
+      );
+    }
+    const result = await context.client.scrapeUrl(url, {
+      formats: ["markdown"],
+      timeout: 30000,
+    });
+
+    if (!result.success || !result.markdown) {
+      throw new Error(`Failed to scrape url: ${url}`);
+    }
+
+    return result.markdown;
+  },
+);
+```
+
+To use the `FirecrawlProvider` and `ScrapePage` component, you would then do the following:
+
+```tsx
+const markdown = await gsx.execute(
+  <FirecrawlProvider apiKey={process.env.FIRECRAWL_API_KEY}>
+    <ScrapePage url="https://gensx.dev/overview/" />
+  </FirecrawlProvider>,
+);
 ```

--- a/docs/src/content/docs/concepts/providers.mdx
+++ b/docs/src/content/docs/concepts/providers.mdx
@@ -5,9 +5,9 @@ sidebar:
   order: 3
 ---
 
-Providers are a specialized use of [contexts](../contexts) that focus on managing configuration and dependencies for your workflow. They're built using the context system described above, but provide a more focused API for configuration management.
+Providers are a specialized use of [contexts](../contexts) that focus on managing configuration and dependencies for your workflow. They're built using the context system, but provide a more focused API for configuration management.
 
-The main provider available today is the `OpenAIProvider`, which manages your OpenAI API key:
+The main provider available today is the `OpenAIProvider`, which manages your OpenAI API key and client:
 
 ```tsx
 const result = await gsx.execute(
@@ -22,10 +22,10 @@ const result = await gsx.execute(
 
 Providers offer several benefits:
 
-- Manage complex configuration like API clients and settings
-- Provide a simpler, more focused API than raw contexts
-- Keep configuration separate from business logic
-- Enable dependency injection for testing and development
+- **Centralized Configuration Management** - providers manage settings like API keys and feature flags keeping configuration separate from business logic.
+- **Data Sharing** - providers give you an easy way to share data between components without prop drilling to simplify your code.
+- **Reusability** - providers and their associated components can easily be reused in different parts of your application.
+- **Scoped State Management** - providers can be used to manage state for parts of your workflow or the entire thing.
 
 ## Creating a Provider
 

--- a/docs/src/content/docs/examples/blog-writing.mdx
+++ b/docs/src/content/docs/examples/blog-writing.mdx
@@ -1,14 +1,89 @@
 ---
-title: Blog writing
+title: Blog Writer
 description: Blog writing agent with Perplexity and GenSX
 sidebar:
   order: 2
 ---
 
-GenSX is a simple framework for building complex generative AI and LLM workflows - think agents, chatbot APIs, RAG, reflection, and more.
+Breaking down complex tasks into smaller, discrete steps is one of the best ways to improve the quality of LLM outputs. The [blog writer workflow example](https://github.com/cortexclick/gensx/tree/main/examples/blogWriter) does this by following the same approach a human would take to write a blog post: first conducting research, then generating a first draft, and finally editing that draft.
 
-It uses `jsx` to define and orchestrate workflows with functional, reusable components:
+## Workflow
+
+The Blog Writer workflow consists of the following steps:
+
+1. Parallel research phase:
+   - Brainstorm topics using LLM (`<LLMResearchBrainstorm>`)
+   - Research each topic in detail (`<LLMResearch>`)
+   - Gather web research (`<WebResearcher>`)
+2. Write initial draft based on research (`<LLMWriter>`)
+3. Edit and polish the content (`<LLMEditor>`)
+
+## Running the example
+
+```bash
+# Install dependencies
+pnpm install
+
+# Set your OpenAI API key
+export OPENAI_API_KEY=<your_api_key>
+
+# Run the example
+pnpm run start
+```
+
+## Key patterns
+
+### Running components in parallel
+
+The `<ParallelResearch>` component runs both the `LLMResearchBrainstorm` and `WebResearcher` components in parallel. Both sub-workflows return an array of strings which are automatically combined into a single array.
 
 ```tsx
-
+const ParallelResearch = gsx.Component<
+  ParallelResearchComponentProps,
+  ParallelResearchOutput
+>("ParallelResearch", ({ prompt }) => {
+  return (
+    <>
+      <LLMResearchBrainstorm prompt={prompt}>
+        {({ topics }) => {
+          return topics.map((topic) => <LLMResearch topic={topic} />);
+        }}
+      </LLMResearchBrainstorm>
+      <WebResearcher prompt={prompt} />
+    </>
+  );
+});
 ```
+
+### Streaming Output
+
+The workflow streams back the final output to reduce the time that it takes for the user to receive the first token. The `<LLMEditor>` component is a [`StreamComponent`](../../basic-concepts#component-types) and the `<ChatCompletion>` component has `stream={true}`.
+
+```tsx
+const LLMEditor = gsx.StreamComponent<LLMEditorProps>(
+  "LLMEditor",
+  ({ draft }) => {
+    return (
+      <ChatCompletion
+        stream={true}
+        model="gpt-4o-mini"
+        temperature={0}
+        messages={[
+          { role: "system", content: systemPrompt },
+          { role: "user", content: draft },
+        ]}
+      />
+    );
+  },
+);
+```
+
+Then when the component is invoked, `stream={true}` is passed to the component so that the output is streamed back and can be surfaced to the user:
+
+```tsx
+<LLMEditor draft={draft} stream={true} />
+```
+
+## Additional resources
+
+Check out the other examples in the [GenSX Github Repo](https://github.com/cortexclick/gensx/tree/main/examples).

--- a/docs/src/content/docs/examples/hn.mdx
+++ b/docs/src/content/docs/examples/hn.mdx
@@ -1,14 +1,87 @@
 ---
-title: Hacker News sentiment analysis
-description: Analyzing Hacker News sentiment with GenSX
+title: Hacker News Analyzer
+description: Extract out key trends from top Hacker News posts
 sidebar:
   order: 1
 ---
 
-GenSX is a simple framework for building complex generative AI and LLM workflows.
+The [Hacker News Analyzer](https://github.com/cortexclick/gensx/tree/main/examples/hackerNewsAnalyzer) example uses GenSX to fetch, analyze, and extract trends from the top Hacker News posts. It shows how to combine data fetching, parallel analysis, and content generation in a single workflow to create two outputs: a detailed report and a tweet of the trends.
 
-It uses `jsx` to define and orchestrate workflows with functional, reusable components:
+## Workflow
+
+The Hacker News Analyzer workflow is composed of the following steps:
+
+1. Fetch the top 500 Hacker News posts and filters down to `text` posts (`<HnCollector>`)
+2. Process each post in parallel (`<AnalyzeHNPosts>`)
+   - Summarize the content (`<PostSummarizer>`)
+   - Analyze the comments (`<CommentsAnalyzer>`)
+3. Writes a detailed report identifying the key trends across all posts (`<TrendsAnalyzer>`)
+4. Edits the report into the style of Paul Graham (`<PGEditor>`)
+5. Generates a tweet in the voice of Paul Graham (`<PGTweetWriter>`)
+
+## Running the example
+
+```bash
+# Install dependencies
+pnpm install
+
+# Set your OpenAI API key
+export OPENAI_API_KEY=<your_api_key>
+
+# Run the example
+pnpm run start
+```
+
+The workflow will create two files:
+
+- `hn_analysis_report.md`: A detailed analysis report
+- `hn_analysis_tweet.txt`: A tweet-sized summary of the analysis
+
+## Key patterns
+
+### Parallel processing
+
+The workflow uses the `<AnalyzeHNPosts>` component to process each post in parallel. GenSX extends JSX to support returning objects so that components can return arrays and structured objects containing other components, which will all be resolved at runtime.
+
+This component takes advantage of this and uses `array.map` to return a list of `analyses`, each containing a summary of the post and an analysis of its comments.
 
 ```tsx
-
+const AnalyzeHNPosts = gsx.Component<AnalyzeHNPostsProps, AnalyzeHNPostsOutput>(
+  "AnalyzeHNPosts",
+  ({ stories }) => {
+    return {
+      analyses: stories.map((story) => ({
+        summary: <PostSummarizer story={story} />,
+        commentAnalysis: (
+          <CommentsAnalyzer postId={story.id} comments={story.comments} />
+        ),
+      })),
+    };
+  },
+);
 ```
+
+### Multiple outputs
+
+This example also shows a simple pattern returning multiple outputs from a workflow. In this case, both the outputs of `<TrendAnalyzer>` and `<PGTweetWriter>` are returned as a single object. This is done by using the the child function of `<PGEditor>` to combine the outputs of multiple components into a single object.
+
+```tsx
+<TrendAnalyzer analyses={analyses}>
+  {(report) => (
+    <PGEditor content={report}>
+      {(editedReport) => (
+        <PGTweetWriter
+          context={editedReport}
+          prompt="Summarize the HN trends in a tweet"
+        >
+          {(tweet) => ({ report: editedReport, tweet })}
+        </PGTweetWriter>
+      )}
+    </PGEditor>
+  )}
+</TrendAnalyzer>
+```
+
+## Additional resources
+
+Check out the other examples in the [GenSX Github Repo](https://github.com/cortexclick/gensx/tree/main/examples).

--- a/examples/README.md
+++ b/examples/README.md
@@ -17,7 +17,7 @@ From there, follow the instructions in the README of the example you want to run
 Alternatively, you can run the examples directly from the root directory of the repo using the following command:
 
 ```bash
-OPENAI_API_KEY=<my api key> turbo run run --filter="./examples/blogWriter"
+OPENAI_API_KEY=<my api key> turbo run start --filter="./examples/blogWriter"
 ```
 
 Make sure to check what environment variables are required for each example.

--- a/examples/README.md
+++ b/examples/README.md
@@ -29,6 +29,7 @@ Make sure to check what environment variables are required for each example.
 | 📊 [Structured Outputs](./structuredOutputs) | Demonstrates using structured outputs with GenSX          |
 | 🔄 [Reflection](./reflection)                | Shows how to use a self-reflection pattern with GenSX     |
 | 🌊 [Streaming](./streaming)                  | Demonstrates how to handle streaming responses with GenSX |
+| 🔌 [Providers](./providers)                  | Shows how to create a custom provider for GenSX           |
 
 ## Full Examples
 

--- a/examples/blogWriter/README.md
+++ b/examples/blogWriter/README.md
@@ -18,7 +18,7 @@ pnpm install
 export OPENAI_API_KEY=<your_api_key>
 
 # Run the example
-pnpm run run
+pnpm run start
 ```
 
 The example will generate a blog post based on the prompt "Write a blog post about the future of AI". You can modify the prompt in `index.tsx` to generate different content.

--- a/examples/blogWriter/package.json
+++ b/examples/blogWriter/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "dev": "nodemon",
-    "run": "NODE_OPTIONS='--enable-source-maps' tsx ./index.tsx",
+    "start": "NODE_OPTIONS='--enable-source-maps' tsx ./index.tsx",
     "build": "tsc",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",

--- a/examples/hackerNewsAnalyzer/README.md
+++ b/examples/hackerNewsAnalyzer/README.md
@@ -19,7 +19,7 @@ pnpm install
 export OPENAI_API_KEY=<your_api_key>
 
 # Run the example
-pnpm run run
+pnpm run start
 ```
 
 The example will:

--- a/examples/hackerNewsAnalyzer/hackerNewsAnalyzer.tsx
+++ b/examples/hackerNewsAnalyzer/hackerNewsAnalyzer.tsx
@@ -324,30 +324,28 @@ export const HNAnalyzerWorkflow = gsx.Component<
 >("HNAnalyzerWorkflow", ({ postCount }) => {
   return (
     <OpenAIProvider apiKey={process.env.OPENAI_API_KEY}>
-      {() => (
-        <HNCollector limit={postCount}>
-          {(stories) => (
-            <AnalyzeHNPosts stories={stories}>
-              {({ analyses }) => (
-                <TrendAnalyzer analyses={analyses}>
-                  {(report) => (
-                    <PGEditor content={report}>
-                      {(editedReport) => (
-                        <PGTweetWriter
-                          context={editedReport}
-                          prompt="Summarize the HN trends in a tweet"
-                        >
-                          {(tweet) => ({ report: editedReport, tweet })}
-                        </PGTweetWriter>
-                      )}
-                    </PGEditor>
-                  )}
-                </TrendAnalyzer>
-              )}
-            </AnalyzeHNPosts>
-          )}
-        </HNCollector>
-      )}
+      <HNCollector limit={postCount}>
+        {(stories) => (
+          <AnalyzeHNPosts stories={stories}>
+            {({ analyses }) => (
+              <TrendAnalyzer analyses={analyses}>
+                {(report) => (
+                  <PGEditor content={report}>
+                    {(editedReport) => (
+                      <PGTweetWriter
+                        context={editedReport}
+                        prompt="Summarize the HN trends in a tweet"
+                      >
+                        {(tweet) => ({ report: editedReport, tweet })}
+                      </PGTweetWriter>
+                    )}
+                  </PGEditor>
+                )}
+              </TrendAnalyzer>
+            )}
+          </AnalyzeHNPosts>
+        )}
+      </HNCollector>
     </OpenAIProvider>
   );
 });

--- a/examples/hackerNewsAnalyzer/hn.ts
+++ b/examples/hackerNewsAnalyzer/hn.ts
@@ -112,7 +112,7 @@ export async function getFullStory(id: number): Promise<HNStory | null> {
 
 export async function getTopStoryDetails(
   limit = 500,
-  batchSize = 10,
+  batchSize = 50,
 ): Promise<HNStory[]> {
   const storyIds = await getTopStories(limit);
   const stories: HNStory[] = [];
@@ -126,7 +126,7 @@ export async function getTopStoryDetails(
 
     // Small delay between batches
     if (i + batchSize < storyIds.length) {
-      await new Promise((resolve) => setTimeout(resolve, 250));
+      await new Promise((resolve) => setTimeout(resolve, 100));
     }
   }
 

--- a/examples/hackerNewsAnalyzer/package.json
+++ b/examples/hackerNewsAnalyzer/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "dev": "nodemon",
-    "run": "NODE_OPTIONS='--enable-source-maps' tsx ./index.tsx",
+    "start": "NODE_OPTIONS='--enable-source-maps' tsx ./index.tsx",
     "build": "tsc",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",

--- a/examples/providers/README.md
+++ b/examples/providers/README.md
@@ -14,7 +14,7 @@ pnpm install
 export FIRECRAWL_API_KEY=<your_api_key>
 
 # Run the example
-pnpm run run
+pnpm run start
 ```
 
 When you run the example, it will scrape the page at `https://gensx.dev/overview/` and return the markdown.

--- a/examples/providers/README.md
+++ b/examples/providers/README.md
@@ -1,0 +1,20 @@
+# Providers Example
+
+This example shows how to create a provider and a related component. In particular, it creates a provider for the [Firecrawl](https://www.firecrawl.dev/) API and uses it to scrape a page and return the markdown.
+
+For more details on providers, see the [Providers](https://gensx.dev/concepts/providers) page.
+
+## Usage
+
+```bash
+# Install dependencies
+pnpm install
+
+# Set your Firecrawl API key
+export FIRECRAWL_API_KEY=<your_api_key>
+
+# Run the example
+pnpm run run
+```
+
+When you run the example, it will scrape the page at `https://gensx.dev/overview/` and return the markdown.

--- a/examples/providers/eslint.config.mjs
+++ b/examples/providers/eslint.config.mjs
@@ -1,0 +1,22 @@
+import rootConfig from "../../eslint.config.mjs";
+
+export default [
+  ...rootConfig,
+  {
+    files: ["**/*.{js,mjs,cjs,jsx,ts,tsx}"],
+    languageOptions: {
+      parserOptions: {
+        tsconfigRootDir: import.meta.dirname,
+        project: "./tsconfig.json",
+      },
+    },
+    rules: {
+      "@typescript-eslint/no-unsafe-assignment": "off",
+      "@typescript-eslint/no-unsafe-call": "off",
+      "@typescript-eslint/no-unsafe-member-access": "off",
+      "@typescript-eslint/no-unsafe-return": "off",
+      "@typescript-eslint/no-unsafe-argument": "off",
+      "node/no-unsupported-features/es-syntax": "off",
+    },
+  },
+];

--- a/examples/providers/firecrawlProvider.tsx
+++ b/examples/providers/firecrawlProvider.tsx
@@ -1,0 +1,46 @@
+import FirecrawlApp, { FirecrawlAppConfig } from "@mendable/firecrawl-js";
+import { gsx } from "gensx";
+
+// Create a context
+export const FirecrawlContext = gsx.createContext<{
+  client?: FirecrawlApp;
+}>({});
+
+// Create the provider
+export const FirecrawlProvider = gsx.Component<FirecrawlAppConfig, never>(
+  "FirecrawlProvider",
+  (args: FirecrawlAppConfig) => {
+    const client = new FirecrawlApp({
+      apiKey: args.apiKey,
+    });
+    return <FirecrawlContext.Provider value={{ client }} />;
+  },
+);
+
+interface ScrapePageProps {
+  url: string;
+}
+
+// Create a component that uses the provider
+export const ScrapePage = gsx.Component<ScrapePageProps, string>(
+  "ScrapePage",
+  async ({ url }) => {
+    const context = gsx.useContext(FirecrawlContext);
+
+    if (!context.client) {
+      throw new Error(
+        "Firecrawl client not found. Please wrap your component with FirecrawlProvider.",
+      );
+    }
+    const result = await context.client.scrapeUrl(url, {
+      formats: ["markdown"],
+      timeout: 30000,
+    });
+
+    if (!result.success || !result.markdown) {
+      throw new Error(`Failed to scrape url: ${url}`);
+    }
+
+    return result.markdown;
+  },
+);

--- a/examples/providers/index.tsx
+++ b/examples/providers/index.tsx
@@ -1,0 +1,18 @@
+import { gsx } from "gensx";
+
+import { FirecrawlProvider, ScrapePage } from "./firecrawlProvider.js";
+
+async function main() {
+  const url = "https://gensx.dev/overview/";
+
+  console.log("\n🚀 Scraping page from url:", url);
+  const markdown = await gsx.execute<string>(
+    <FirecrawlProvider apiKey={process.env.FIRECRAWL_API_KEY}>
+      <ScrapePage url={url} />
+    </FirecrawlProvider>,
+  );
+  console.log("\n✅ Scraping complete");
+  console.log("\n🚀 Scraped markdown:", markdown);
+}
+
+main().catch(console.error);

--- a/examples/providers/nodemon.json
+++ b/examples/providers/nodemon.json
@@ -1,0 +1,5 @@
+{
+  "watch": [".", ".env", "../../packages/**/dist/**"],
+  "exec": "NODE_OPTIONS='--enable-source-maps' tsx --inspect=0.0.0.0:9229 ./index.tsx",
+  "ext": "ts, tsx, js, json"
+}

--- a/examples/providers/package.json
+++ b/examples/providers/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@gensx-examples/providers",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "engines": {
+    "node": ">=18.0.0"
+  },
+  "scripts": {
+    "dev": "nodemon",
+    "run": "NODE_OPTIONS='--enable-source-maps' tsx ./index.tsx",
+    "build": "tsc",
+    "lint": "eslint .",
+    "lint:fix": "eslint . --fix",
+    "test": "NODE_OPTIONS='--enable-source-maps' tsx ./index.tsx"
+  },
+  "dependencies": {
+    "@gensx/openai": "workspace:*",
+    "@mendable/firecrawl-js": "^1.15.7",
+    "gensx": "workspace:*",
+    "openai": "^4.77.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20.17.11",
+    "nodemon": "^3.1.9",
+    "tsx": "^4.19.2",
+    "typescript": "^5.0.0"
+  }
+}

--- a/examples/providers/package.json
+++ b/examples/providers/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "dev": "nodemon",
-    "run": "NODE_OPTIONS='--enable-source-maps' tsx ./index.tsx",
+    "start": "NODE_OPTIONS='--enable-source-maps' tsx ./index.tsx",
     "build": "tsc",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",

--- a/examples/providers/tsconfig.json
+++ b/examples/providers/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "NodeNext",
+    "lib": ["ESNext", "DOM"],
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "moduleResolution": "NodeNext",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "react-jsx",
+    "jsxImportSource": "gensx",
+    "outDir": "./dist"
+  },
+  "include": ["./*.ts", "./*.tsx", "./**/*.ts", "./**/*.tsx"],
+  "exclude": ["node_modules"]
+}

--- a/examples/reflection/README.md
+++ b/examples/reflection/README.md
@@ -18,8 +18,11 @@ This example demonstrates how to use GenSX's `gsx.execute` to execute sub-workfl
 # Install dependencies
 pnpm install
 
+# Set your OpenAI API key
+export OPENAI_API_KEY=<your_api_key>
+
 # Run the example
-OPENAI_API_KEY=<your_api_key> npm run run
+pnpm run start
 ```
 
 The example will clean a sample text containing business buzzwords. You can modify the input text in `index.tsx` to clean different content.

--- a/examples/reflection/package.json
+++ b/examples/reflection/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "dev": "nodemon",
-    "run": "NODE_OPTIONS='--enable-source-maps' tsx ./index.tsx",
+    "start": "NODE_OPTIONS='--enable-source-maps' tsx ./index.tsx",
     "build": "tsc",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",

--- a/examples/streaming/README.md
+++ b/examples/streaming/README.md
@@ -19,7 +19,7 @@ pnpm install
 export OPENAI_API_KEY=<your_api_key>
 
 # Run the example
-pnpm run run
+pnpm run start
 ```
 
 The example will run two versions of the same prompt:

--- a/examples/streaming/package.json
+++ b/examples/streaming/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "dev": "nodemon",
-    "run": "NODE_OPTIONS='--enable-source-maps' tsx ./index.tsx",
+    "start": "NODE_OPTIONS='--enable-source-maps' tsx ./index.tsx",
     "build": "tsc",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix"

--- a/examples/structuredOutputs/README.md
+++ b/examples/structuredOutputs/README.md
@@ -12,5 +12,5 @@ pnpm install
 export OPENAI_API_KEY=<your_api_key>
 
 # Run the example
-pnpm run run
+pnpm run start
 ```

--- a/examples/structuredOutputs/package.json
+++ b/examples/structuredOutputs/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "dev": "nodemon",
-    "run": "NODE_OPTIONS='--enable-source-maps' tsx ./index.tsx",
+    "start": "NODE_OPTIONS='--enable-source-maps' tsx ./index.tsx",
     "build": "tsc",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",

--- a/packages/create-gensx/CHANGELOG.md
+++ b/packages/create-gensx/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## [0.1.5](https://github.com/cortexclick/gensx/compare/create-gensx-v0.1.4...create-gensx-v0.1.5) (2025-01-21)
+
+
+### ✨ New Features
+
+* Add support for component names ([#120](https://github.com/cortexclick/gensx/issues/120)) ([cc5d69c](https://github.com/cortexclick/gensx/commit/cc5d69c7c3d39f60ea85db351e445a6b1d3ef47b))
+* Implement `createContext` and `useContext` ([#90](https://github.com/cortexclick/gensx/issues/90)) ([4c30f67](https://github.com/cortexclick/gensx/commit/4c30f6726c680fdabcf62734eed5035b618b2b17)), closes [#89](https://github.com/cortexclick/gensx/issues/89)
+
+
+### 🐛 Bug Fixes
+
+* Update vite-plugin-dts. ([#122](https://github.com/cortexclick/gensx/issues/122)) ([b831a67](https://github.com/cortexclick/gensx/commit/b831a670d43b2b089847c8fd244fcd178a2b2afc))
+
+
+### 📚 Documentation
+
+* adding basic concepts doc and refactoring quickstart ([#128](https://github.com/cortexclick/gensx/issues/128)) ([6a36077](https://github.com/cortexclick/gensx/commit/6a3607779e9d934ae1b980c76b72b53f9b2e02af))
+
 ## [0.1.4](https://github.com/cortexclick/gensx/compare/create-gensx-v0.1.3...create-gensx-v0.1.4) (2025-01-07)
 
 

--- a/packages/create-gensx/package.json
+++ b/packages/create-gensx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-gensx",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "type": "module",
   "license": "Apache-2.0",
   "engines": {

--- a/packages/gensx-openai/CHANGELOG.md
+++ b/packages/gensx-openai/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## [0.1.3](https://github.com/cortexclick/gensx/compare/gensx-openai-v0.1.2...gensx-openai-v0.1.3) (2025-01-21)
+
+
+### ✨ New Features
+
+* Add support for component names ([#120](https://github.com/cortexclick/gensx/issues/120)) ([cc5d69c](https://github.com/cortexclick/gensx/commit/cc5d69c7c3d39f60ea85db351e445a6b1d3ef47b))
+* Implement `createContext` and `useContext` ([#90](https://github.com/cortexclick/gensx/issues/90)) ([4c30f67](https://github.com/cortexclick/gensx/commit/4c30f6726c680fdabcf62734eed5035b618b2b17)), closes [#89](https://github.com/cortexclick/gensx/issues/89)
+
+
+### 🐛 Bug Fixes
+
+* Update vite-plugin-dts. ([#122](https://github.com/cortexclick/gensx/issues/122)) ([b831a67](https://github.com/cortexclick/gensx/commit/b831a670d43b2b089847c8fd244fcd178a2b2afc))
+
 ## [0.1.2](https://github.com/cortexclick/gensx/compare/gensx-openai-v0.1.1...gensx-openai-v0.1.2) (2025-01-11)
 
 

--- a/packages/gensx-openai/package.json
+++ b/packages/gensx-openai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gensx/openai",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "OpenAI integration for GenSX",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/gensx/CHANGELOG.md
+++ b/packages/gensx/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [0.2.3](https://github.com/cortexclick/gensx/compare/gensx-v0.2.2...gensx-v0.2.3) (2025-01-21)
+
+
+### ✨ New Features
+
+* Add checkpointing ([#143](https://github.com/cortexclick/gensx/issues/143)) ([645d537](https://github.com/cortexclick/gensx/commit/645d53707efc50a7f8cf5426982cd7d269d92255))
+* Add support for component names ([#120](https://github.com/cortexclick/gensx/issues/120)) ([cc5d69c](https://github.com/cortexclick/gensx/commit/cc5d69c7c3d39f60ea85db351e445a6b1d3ef47b))
+* Implement `createContext` and `useContext` ([#90](https://github.com/cortexclick/gensx/issues/90)) ([4c30f67](https://github.com/cortexclick/gensx/commit/4c30f6726c680fdabcf62734eed5035b618b2b17)), closes [#89](https://github.com/cortexclick/gensx/issues/89)
+
+
+### 🐛 Bug Fixes
+
+* Update vite-plugin-dts. ([#122](https://github.com/cortexclick/gensx/issues/122)) ([b831a67](https://github.com/cortexclick/gensx/commit/b831a670d43b2b089847c8fd244fcd178a2b2afc))
+
 ## [0.2.2](https://github.com/cortexclick/gensx/compare/gensx-v0.2.1...gensx-v0.2.2) (2025-01-10)
 
 

--- a/packages/gensx/package.json
+++ b/packages/gensx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gensx",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Build AI workflows using JSX",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/gensx/src/checkpoint.ts
+++ b/packages/gensx/src/checkpoint.ts
@@ -1,0 +1,175 @@
+import { join } from "node:path";
+
+// Cross-platform UUID generation
+async function generateUUID(): Promise<string> {
+  try {
+    // Try Node.js crypto first
+    const crypto = await import("node:crypto");
+    return crypto.randomUUID();
+  } catch {
+    // Fallback to browser crypto
+    if (typeof globalThis !== "undefined") {
+      return globalThis.crypto.randomUUID();
+    }
+    // Simple fallback for environments without crypto
+    return "xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx".replace(/[xy]/g, c => {
+      const r = (Math.random() * 16) | 0;
+      const v = c === "x" ? r : (r & 0x3) | 0x8;
+      return v.toString(16);
+    });
+  }
+}
+
+export interface ExecutionNode {
+  id: string;
+  componentName: string;
+  parentId?: string;
+  startTime: number;
+  endTime?: number;
+  props: Record<string, unknown>;
+  output?: unknown;
+  children: ExecutionNode[];
+  metadata?: {
+    logs?: string[];
+    tokenCounts?: {
+      input: number;
+      output: number;
+    };
+    [key: string]: unknown;
+  };
+}
+
+export interface CheckpointWriter {
+  root?: ExecutionNode;
+  addNode: (node: Partial<ExecutionNode>, parentId?: string) => Promise<string>;
+  completeNode: (id: string, output: unknown) => void;
+  addMetadata: (id: string, metadata: Record<string, unknown>) => void;
+  write: () => void;
+  checkpointsEnabled: boolean;
+}
+
+export class CheckpointManager implements CheckpointWriter {
+  private nodes = new Map<string, ExecutionNode>();
+  public root?: ExecutionNode;
+  public checkpointsEnabled: boolean;
+
+  // Track active checkpoint write
+  private activeCheckpoint: Promise<void> | null = null;
+  private pendingUpdate = false;
+
+  constructor() {
+    // Set checkpointsEnabled based on environment variable
+    // Environment variables are strings, so check for common truthy values
+    const checkpointsEnv = process.env.GENSX_CHECKPOINTS?.toLowerCase();
+    this.checkpointsEnabled =
+      checkpointsEnv === "true" ||
+      checkpointsEnv === "1" ||
+      checkpointsEnv === "yes";
+  }
+
+  // updateCheckpoint POSTs the current component tree to the GenSX API.
+  // Special care is taken to do this in a non-blocking manner, and in a way that
+  // minimizes chattiness with the server.
+  // We only write one checkpoint at a time. If another checkpoint comes in while
+  // we're still processing, we just mark that we need another update and return.
+  // When the current checkpoint write is complete, we check if there was a pending
+  // update request, and if so, we trigger another write.
+  private updateCheckpoint() {
+    if (!this.checkpointsEnabled || !this.root) {
+      return;
+    }
+
+    // If there's already a pending update, just mark that we need another update
+    if (this.activeCheckpoint) {
+      this.pendingUpdate = true;
+      return;
+    }
+
+    // Start a new checkpoint write
+    this.activeCheckpoint = this.writeCheckpoint().finally(() => {
+      this.activeCheckpoint = null;
+
+      // If there was a pending update requested while we were writing,
+      // trigger another write
+      if (this.pendingUpdate) {
+        this.pendingUpdate = false;
+        this.updateCheckpoint();
+      }
+    });
+  }
+
+  private async writeCheckpoint() {
+    if (!this.root) return;
+
+    try {
+      const baseUrl =
+        process.env.GENSX_CHECKPOINT_URL ?? "http://localhost:3000";
+      const url = join(baseUrl, "api/execution");
+      const response = await fetch(url, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(this.root),
+      });
+
+      if (!response.ok) {
+        console.error(`[Checkpoint] Failed to save checkpoint, server error:`, {
+          status: response.status,
+          message: await response.text(),
+        });
+      }
+    } catch (error) {
+      console.error(`[Checkpoint] Failed to save checkpoint:`, { error });
+    }
+  }
+
+  async addNode(partialNode: Partial<ExecutionNode>, parentId?: string) {
+    const node: ExecutionNode = {
+      id: await generateUUID(),
+      componentName: "Unknown",
+      startTime: Date.now(),
+      children: [],
+      props: {},
+      ...partialNode,
+    };
+
+    this.nodes.set(node.id, node);
+
+    if (parentId) {
+      const parent = this.nodes.get(parentId);
+      if (parent) {
+        node.parentId = parentId;
+        parent.children.push(node);
+      }
+    } else if (!this.root) {
+      this.root = node;
+    }
+
+    this.updateCheckpoint();
+    return node.id;
+  }
+
+  completeNode(id: string, output: unknown) {
+    const node = this.nodes.get(id);
+    if (node) {
+      node.endTime = Date.now();
+      node.output = output;
+      this.updateCheckpoint();
+    } else {
+      console.warn(`[Tracker] Attempted to complete unknown node:`, { id });
+    }
+  }
+
+  addMetadata(id: string, metadata: Record<string, unknown>) {
+    const node = this.nodes.get(id);
+    if (node) {
+      node.metadata = { ...node.metadata, ...metadata };
+      this.updateCheckpoint();
+    }
+  }
+
+  write() {
+    this.updateCheckpoint();
+  }
+}

--- a/packages/gensx/src/resolve.ts
+++ b/packages/gensx/src/resolve.ts
@@ -1,4 +1,4 @@
-import { ExecutionContext } from "./context";
+import { ExecutionContext, getCurrentContext } from "./context";
 import { isStreamable } from "./stream";
 import { ExecutableValue } from "./types";
 
@@ -53,5 +53,8 @@ export async function resolveDeep<T>(value: unknown): Promise<T> {
  * This is the main entry point for executing workflow components.
  */
 export async function execute<T>(element: ExecutableValue): Promise<T> {
-  return (await resolveDeep(element)) as T;
+  const context = getCurrentContext().getWorkflowContext();
+  const result = (await resolveDeep(element)) as T;
+  context.checkpointManager.write();
+  return result;
 }

--- a/packages/gensx/src/workflow-context.ts
+++ b/packages/gensx/src/workflow-context.ts
@@ -1,0 +1,21 @@
+import { CheckpointManager } from "./checkpoint";
+import { getCurrentContext } from "./context";
+
+// Static symbol for workflow context
+export const WORKFLOW_CONTEXT_SYMBOL = Symbol.for("gensx.workflow");
+
+export interface WorkflowExecutionContext {
+  checkpointManager: CheckpointManager;
+  // Future: Add more workflow-level utilities here
+}
+
+export function createWorkflowContext(): WorkflowExecutionContext {
+  return {
+    checkpointManager: new CheckpointManager(),
+  };
+}
+
+export function getWorkflowContext(): WorkflowExecutionContext | undefined {
+  const context = getCurrentContext();
+  return context.getWorkflowContext();
+}

--- a/packages/gensx/tests/checkpoint.test.tsx
+++ b/packages/gensx/tests/checkpoint.test.tsx
@@ -1,0 +1,360 @@
+import { setTimeout } from "timers/promises";
+
+import type { ExecutionNode } from "@/checkpoint.js";
+import type { ExecutableValue } from "@/types.js";
+
+import { afterEach, beforeEach, expect, suite, test, vi } from "vitest";
+
+import { CheckpointManager } from "@/checkpoint.js";
+import { ExecutionContext, withContext } from "@/context.js";
+import { gsx } from "@/index.js";
+import { createWorkflowContext } from "@/workflow-context.js";
+
+// Add types for fetch API
+type FetchInput = Parameters<typeof fetch>[0];
+type FetchInit = Parameters<typeof fetch>[1];
+
+/**
+ * Helper to execute a workflow with checkpoint tracking
+ * Returns both the execution result and recorded checkpoints for verification
+ */
+
+// eslint-disable-next-line @typescript-eslint/no-unnecessary-type-parameters
+async function executeWithCheckpoints<T>(
+  element: ExecutableValue,
+): Promise<{ result: T; checkpoints: ExecutionNode[] }> {
+  const checkpoints: ExecutionNode[] = [];
+
+  // Set up fetch mock to capture checkpoints
+  global.fetch = vi
+    .fn()
+    // eslint-disable-next-line @typescript-eslint/require-await
+    .mockImplementation(async (_input: FetchInput, options?: FetchInit) => {
+      if (!options?.body) throw new Error("No body provided");
+      const checkpoint = JSON.parse(options.body as string) as ExecutionNode;
+      checkpoints.push(checkpoint);
+      return new Response(null, { status: 200 });
+    });
+
+  // Create and configure workflow context
+  const checkpointManager = new CheckpointManager();
+  const workflowContext = createWorkflowContext();
+  workflowContext.checkpointManager = checkpointManager;
+  const executionContext = new ExecutionContext({});
+  const contextWithWorkflow = executionContext.withContext({
+    [Symbol.for("gensx.workflow")]: workflowContext,
+  });
+
+  // Execute with context
+  const result = await withContext(contextWithWorkflow, () =>
+    gsx.execute<T>(element),
+  );
+
+  return { result, checkpoints };
+}
+
+suite("checkpoint", () => {
+  const originalFetch = global.fetch;
+  const originalEnv = process.env.GENSX_CHECKPOINTS;
+
+  beforeEach(() => {
+    process.env.GENSX_CHECKPOINTS = "true";
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    process.env.GENSX_CHECKPOINTS = originalEnv;
+    vi.restoreAllMocks();
+  });
+
+  test("basic component test", async () => {
+    // Define a simple component that returns a string
+    const SimpleComponent = gsx.Component<{ message: string }, string>(
+      "SimpleComponent",
+      async ({ message }) => {
+        await setTimeout(0); // Add small delay like other tests
+        return `hello ${message}`;
+      },
+    );
+
+    // Execute workflow and get results
+    const { result, checkpoints } = await executeWithCheckpoints<string>(
+      <SimpleComponent message="world" />,
+    );
+
+    // Verify execution result
+    expect(result).toBe("hello world");
+
+    // Verify checkpoint calls were made
+    expect(global.fetch).toHaveBeenCalled();
+
+    // Get final checkpoint state
+    const finalCheckpoint = checkpoints[checkpoints.length - 1];
+
+    // Verify checkpoint structure
+    expect(finalCheckpoint).toMatchObject({
+      componentName: "SimpleComponent",
+      props: { message: "world" },
+      output: "hello world",
+    });
+
+    // Verify timing fields
+    expect(finalCheckpoint.startTime).toBeDefined();
+    expect(finalCheckpoint.endTime).toBeDefined();
+    expect(finalCheckpoint.startTime).toBeLessThan(finalCheckpoint.endTime!);
+  });
+
+  test("no checkpoints when disabled", async () => {
+    // Disable checkpoints
+    process.env.GENSX_CHECKPOINTS = undefined;
+
+    // Define a simple component that returns a string
+    const SimpleComponent = gsx.Component<{ message: string }, string>(
+      "SimpleComponent",
+      async ({ message }) => {
+        await setTimeout(0);
+        return `hello ${message}`;
+      },
+    );
+
+    // Execute workflow and get results
+    const { result, checkpoints } = await executeWithCheckpoints<string>(
+      <SimpleComponent message="world" />,
+    );
+
+    // Verify execution still works
+    expect(result).toBe("hello world");
+
+    // Verify no checkpoint calls were made
+    expect(global.fetch).not.toHaveBeenCalled();
+    expect(checkpoints).toHaveLength(0);
+  });
+
+  test("handles parallel execution", async () => {
+    // Define a simple component that we'll use many times
+    const SimpleComponent = gsx.Component<{ id: number }, string>(
+      "SimpleComponent",
+      async ({ id }) => {
+        await setTimeout(0); // Small delay to ensure parallel execution
+        return `component ${id}`;
+      },
+    );
+
+    // Create a component that returns an array of parallel executions
+    const ParallelComponent = gsx.Component<{}, string[]>(
+      "ParallelComponent",
+      async () => {
+        return Promise.all(
+          Array.from({ length: 100 }).map((_, i) =>
+            gsx.execute<string>(<SimpleComponent id={i} />),
+          ),
+        );
+      },
+    );
+
+    // Execute workflow and get results
+    const { result, checkpoints } = await executeWithCheckpoints<string[]>(
+      <ParallelComponent />,
+    );
+
+    // Verify execution result
+    expect(result).toHaveLength(100);
+    expect(result[0]).toBe("component 0");
+    expect(result[99]).toBe("component 99");
+
+    // Verify checkpoint behavior
+    const fetchCalls = (global.fetch as unknown as ReturnType<typeof vi.fn>)
+      .mock.calls.length;
+
+    // We expect:
+    // - Some minimum number of calls to capture the state (could be heavily batched)
+    // - Less than the theoretical maximum (303 = parent(2) + children(200) + execute calls(101))
+    // - Evidence of queueing (significantly less than theoretical maximum)
+    expect(fetchCalls).toBeGreaterThan(0); // At least some calls must happen
+    expect(fetchCalls).toBeLessThan(303); // Less than theoretical maximum
+    expect(fetchCalls).toBeLessThan(250); // Evidence of significant queueing
+
+    // Verify we have all nodes
+    const finalCheckpoint = checkpoints[checkpoints.length - 1];
+    expect(finalCheckpoint.componentName).toBe("ParallelComponent");
+
+    function countNodes(node: ExecutionNode): number {
+      return (
+        1 + node.children.reduce((sum, child) => sum + countNodes(child), 0)
+      );
+    }
+    expect(countNodes(finalCheckpoint)).toBe(101);
+    expect(finalCheckpoint.children.length).toBe(100);
+  });
+
+  test("handles sequential execute calls within component", async () => {
+    // Define a simple component that we'll use multiple times
+    const SimpleComponent = gsx.Component<{ id: number }, string>(
+      "SimpleComponent",
+      async ({ id }) => {
+        await setTimeout(0);
+        return `component ${id}`;
+      },
+    );
+
+    // Create a component that makes three sequential execute calls
+    const ParentComponent = gsx.Component<{}, string>(
+      "ParentComponent",
+      async () => {
+        const first = await gsx.execute<string>(<SimpleComponent id={1} />);
+        const second = await gsx.execute<string>(<SimpleComponent id={2} />);
+        const third = await gsx.execute<string>(<SimpleComponent id={3} />);
+        return `${first}, ${second}, ${third}`;
+      },
+    );
+
+    // Execute workflow and get results
+    const { result, checkpoints } = await executeWithCheckpoints<string>(
+      <ParentComponent />,
+    );
+
+    // Verify execution result
+    expect(result).toBe("component 1, component 2, component 3");
+
+    // Get final checkpoint state
+    const finalCheckpoint = checkpoints[checkpoints.length - 1];
+    expect(finalCheckpoint.componentName).toBe("ParentComponent");
+
+    // For now, verify we have the right number of total nodes (1 parent + 3 children)
+    function countNodes(node: ExecutionNode): number {
+      return (
+        1 + node.children.reduce((sum, child) => sum + countNodes(child), 0)
+      );
+    }
+    expect(countNodes(finalCheckpoint)).toBe(4);
+    expect(finalCheckpoint.children.length).toBe(3);
+  });
+
+  test("handles component children with object return", async () => {
+    // Define child components
+    const ComponentA = gsx.Component<{ value: string }, string>(
+      "ComponentA",
+      async ({ value }) => {
+        await setTimeout(0);
+        return `a:${value}`;
+      },
+    );
+
+    const ComponentB = gsx.Component<{ value: string }, string>(
+      "ComponentB",
+      async ({ value }) => {
+        await setTimeout(0);
+        return `b:${value}`;
+      },
+    );
+
+    // Create parent component that returns an object with multiple children
+    const ParentComponent = gsx.Component<{}, { a: string; b: string }>(
+      "ParentComponent",
+      () => {
+        return {
+          a: <ComponentA value="first" />,
+          b: <ComponentB value="second" />,
+        };
+      },
+    );
+
+    // Execute workflow and get results
+    const { result, checkpoints } = await executeWithCheckpoints<{
+      a: string;
+      b: string;
+    }>(<ParentComponent />);
+
+    // Verify execution result
+    expect(result).toEqual({
+      a: "a:first",
+      b: "b:second",
+    });
+
+    // Get final checkpoint state
+    const finalCheckpoint = checkpoints[checkpoints.length - 1];
+
+    // Verify checkpoint structure
+    expect(finalCheckpoint).toMatchObject({
+      componentName: "ParentComponent",
+      children: [
+        {
+          componentName: "ComponentA",
+          children: [],
+          output: "a:first",
+          props: { value: "first" },
+        },
+        {
+          componentName: "ComponentB",
+          output: "b:second",
+          props: { value: "second" },
+          children: [],
+        },
+      ],
+      output: { a: "a:first", b: "b:second" },
+    });
+  });
+
+  test("handles nested component hierarchy", async () => {
+    // Define components that will be nested
+    const ComponentC = gsx.Component<{ value: string }, string>(
+      "ComponentC",
+      async ({ value }) => {
+        await setTimeout(0);
+        return `c:${value}`;
+      },
+    );
+
+    const ComponentB = gsx.Component<{ value: string }, string>(
+      "ComponentB",
+      async ({ value }) => {
+        const inner = await gsx.execute<string>(
+          <ComponentC value={`${value}-inner`} />,
+        );
+        return `b:${value}(${inner})`;
+      },
+    );
+
+    const ComponentA = gsx.Component<{ value: string }, string>(
+      "ComponentA",
+      async ({ value }) => {
+        const middle = await gsx.execute<string>(
+          <ComponentB value={`${value}-middle`} />,
+        );
+        return `a:${value}(${middle})`;
+      },
+    );
+
+    // Execute workflow and get results
+    const { result, checkpoints } = await executeWithCheckpoints<string>(
+      <ComponentA value="outer" />,
+    );
+
+    // Verify execution result
+    expect(result).toBe("a:outer(b:outer-middle(c:outer-middle-inner))");
+
+    // Get final checkpoint state
+    const finalCheckpoint = checkpoints[checkpoints.length - 1];
+
+    // Verify checkpoint structure shows proper nesting
+    expect(finalCheckpoint).toMatchObject({
+      componentName: "ComponentA",
+      props: { value: "outer" },
+      output: "a:outer(b:outer-middle(c:outer-middle-inner))",
+      children: [
+        {
+          componentName: "ComponentB",
+          props: { value: "outer-middle" },
+          output: "b:outer-middle(c:outer-middle-inner)",
+          children: [
+            {
+              componentName: "ComponentC",
+              props: { value: "outer-middle-inner" },
+              output: "c:outer-middle-inner",
+            },
+          ],
+        },
+      ],
+    });
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -135,6 +135,34 @@ importers:
         specifier: ^5.0.0
         version: 5.7.2
 
+  examples/providers:
+    dependencies:
+      '@gensx/openai':
+        specifier: workspace:*
+        version: link:../../packages/gensx-openai
+      '@mendable/firecrawl-js':
+        specifier: ^1.15.7
+        version: 1.15.7(ws@8.18.0)
+      gensx:
+        specifier: workspace:*
+        version: link:../../packages/gensx
+      openai:
+        specifier: ^4.77.0
+        version: 4.77.4(zod@3.24.1)
+    devDependencies:
+      '@types/node':
+        specifier: ^20.17.11
+        version: 20.17.11
+      nodemon:
+        specifier: ^3.1.9
+        version: 3.1.9
+      tsx:
+        specifier: ^4.19.2
+        version: 4.19.2
+      typescript:
+        specifier: ^5.0.0
+        version: 5.7.2
+
   examples/reflection:
     dependencies:
       '@gensx/openai':
@@ -1328,6 +1356,9 @@ packages:
   '@mdx-js/mdx@3.1.0':
     resolution: {integrity: sha512-/QxEhPAvGwbQmy1Px8F899L5Uc2KZ6JtXwlCgJmjSTBedwOZkByYcBG4GceIGPXRDsmfxhHazuS+hlOShRLeDw==}
 
+  '@mendable/firecrawl-js@1.15.7':
+    resolution: {integrity: sha512-avCwLyzEtrD/D+gchvmbrlThRyeqVXozVGMalDlCnb3cBfm6iRv99PbiZNu/vy6I+kuz/lbxCMewnVPbCr4VCw==}
+
   '@microsoft/api-extractor-model@7.28.13':
     resolution: {integrity: sha512-39v/JyldX4MS9uzHcdfmjjfS6cYGAoXV+io8B5a338pkHiSt+gy2eXQ0Q7cGFJ7quSa1VqqlMdlPrB6sLR/cAw==}
 
@@ -2040,6 +2071,9 @@ packages:
     peerDependencies:
       postcss: ^8.1.0
 
+  axios@1.7.9:
+    resolution: {integrity: sha512-LhLcE7Hbiryz8oMDdDptSrWowmB4Bl6RCt6sIJKpRB4XtVf0iEgewX3au/pJqm+Py1kCASkb/FFKjxQaLtxJvw==}
+
   axobject-query@4.1.0:
     resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
     engines: {node: '>= 0.4'}
@@ -2626,6 +2660,15 @@ packages:
     resolution: {integrity: sha512-9UbaD6XdAL97+k/n+N7JwX46K/M6Zc6KcFYskrYL8wbBV/Uyk0CTAMY0VT+qiK5PM7AIc9aTWYtq65U7T+aCNQ==}
     engines: {node: '>=8'}
 
+  follow-redirects@1.15.9:
+    resolution: {integrity: sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==}
+    engines: {node: '>=4.0'}
+    peerDependencies:
+      debug: '*'
+    peerDependenciesMeta:
+      debug:
+        optional: true
+
   foreground-child@3.3.0:
     resolution: {integrity: sha512-Ld2g8rrAyMYFXBhEqMz8ZAHBi4J4uS1i/CxGMDnjyFWddMXLVcDp051DZfu+t7+ab7Wv6SMqpWmyFIj5UbfFvg==}
     engines: {node: '>=14'}
@@ -2930,6 +2973,11 @@ packages:
 
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
+  isows@1.0.6:
+    resolution: {integrity: sha512-lPHCayd40oW98/I0uvgaHKWCSvkzY27LjWLbtzOm64yQ+G3Q5npjjbdppU65iZXkK1Zt+kH9pfegli0AYfwYYw==}
+    peerDependencies:
+      ws: '*'
 
   istanbul-lib-coverage@3.2.2:
     resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
@@ -3635,6 +3683,9 @@ packages:
   property-information@6.5.0:
     resolution: {integrity: sha512-PgTgs/BlvHxOu8QuEN7wi5A0OmXaBcHpmCSTehcs6Uuu9IkDIEo13Hy7n898RHfrQ49vKCoGeWZSaAK01nwVig==}
 
+  proxy-from-env@1.1.0:
+    resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
+
   pstree.remy@1.1.8:
     resolution: {integrity: sha512-77DZwxQmxKnu3aR542U+X8FypNzbfJ+C5XQDk3uWjWxn6151aIMGthWYRXTqT1E5oJvg+ljaa2OJi+VfvCOQ8w==}
 
@@ -4116,6 +4167,9 @@ packages:
   type-fest@4.31.0:
     resolution: {integrity: sha512-yCxltHW07Nkhv/1F6wWBr8kz+5BGMfP+RbRSYFnegVb0qV/UMT0G0ElBloPVerqn4M2ZV80Ir1FtCcYv1cT6vQ==}
     engines: {node: '>=16'}
+
+  typescript-event-target@1.1.1:
+    resolution: {integrity: sha512-dFSOFBKV6uwaloBCCUhxlD3Pr/P1a/tJdcmPrTXCHlEFD3faj0mztjcGn6VBAhQ0/Bdy8K3VWrrqwbt/ffsYsg==}
 
   typescript@5.4.2:
     resolution: {integrity: sha512-+2/g0Fds1ERlP6JsakQQDXjZdZMM+rqpamFZJEKh4kwTIn3iDkgKtby0CeNd5ATNZ4Ry1ax15TMx0W2V+miizQ==}
@@ -5585,6 +5639,17 @@ snapshots:
       - acorn
       - supports-color
 
+  '@mendable/firecrawl-js@1.15.7(ws@8.18.0)':
+    dependencies:
+      axios: 1.7.9
+      isows: 1.0.6(ws@8.18.0)
+      typescript-event-target: 1.1.1
+      zod: 3.24.1
+      zod-to-json-schema: 3.24.1(zod@3.24.1)
+    transitivePeerDependencies:
+      - debug
+      - ws
+
   '@microsoft/api-extractor-model@7.28.13(@types/node@22.10.5)':
     dependencies:
       '@microsoft/tsdoc': 0.14.2
@@ -6485,6 +6550,14 @@ snapshots:
       postcss: 8.4.49
       postcss-value-parser: 4.2.0
 
+  axios@1.7.9:
+    dependencies:
+      follow-redirects: 1.15.9
+      form-data: 4.0.1
+      proxy-from-env: 1.1.0
+    transitivePeerDependencies:
+      - debug
+
   axobject-query@4.1.0: {}
 
   bail@2.0.2: {}
@@ -7131,6 +7204,8 @@ snapshots:
 
   flattie@1.1.1: {}
 
+  follow-redirects@1.15.9: {}
+
   foreground-child@3.3.0:
     dependencies:
       cross-spawn: 7.0.6
@@ -7542,6 +7617,10 @@ snapshots:
       is-inside-container: 1.0.0
 
   isexe@2.0.0: {}
+
+  isows@1.0.6(ws@8.18.0):
+    dependencies:
+      ws: 8.18.0
 
   istanbul-lib-coverage@3.2.2: {}
 
@@ -8528,6 +8607,8 @@ snapshots:
 
   property-information@6.5.0: {}
 
+  proxy-from-env@1.1.0: {}
+
   pstree.remy@1.1.8: {}
 
   punycode@2.3.1: {}
@@ -9128,6 +9209,8 @@ snapshots:
   type-fest@0.20.2: {}
 
   type-fest@4.31.0: {}
+
+  typescript-event-target@1.1.1: {}
 
   typescript@5.4.2: {}
 


### PR DESCRIPTION
Adds the concept doc for providers

Also adds a provider example that shows how to create a provider for Firecrawl (that is discussed in the doc)

It's worth noting that the top of this doc is the same as the text from the basic concepts page but it extends the info. Eventually we will also want an "Available Providers" section but when written currently, it only contains the OpenAIProvider.