### PR TITLE
style: updating all examples to use "start" instead of "run"

### DIFF
--- a/examples/blogWriter/README.md
+++ b/examples/blogWriter/README.md
@@ -18,7 +18,7 @@ pnpm install
 export OPENAI_API_KEY=<your_api_key>
 
 # Run the example
-pnpm run run
+pnpm run start
 ```
 
 The example will generate a blog post based on the prompt "Write a blog post about the future of AI". You can modify the prompt in `index.tsx` to generate different content.

--- a/examples/blogWriter/package.json
+++ b/examples/blogWriter/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "dev": "nodemon",
-    "run": "NODE_OPTIONS='--enable-source-maps' tsx ./index.tsx",
+    "start": "NODE_OPTIONS='--enable-source-maps' tsx ./index.tsx",
     "build": "tsc",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",

--- a/examples/hackerNewsAnalyzer/README.md
+++ b/examples/hackerNewsAnalyzer/README.md
@@ -19,7 +19,7 @@ pnpm install
 export OPENAI_API_KEY=<your_api_key>
 
 # Run the example
-pnpm run run
+pnpm run start
 ```
 
 The example will:

--- a/examples/hackerNewsAnalyzer/package.json
+++ b/examples/hackerNewsAnalyzer/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "dev": "nodemon",
-    "run": "NODE_OPTIONS='--enable-source-maps' tsx ./index.tsx",
+    "start": "NODE_OPTIONS='--enable-source-maps' tsx ./index.tsx",
     "build": "tsc",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",

--- a/examples/reflection/README.md
+++ b/examples/reflection/README.md
@@ -18,8 +18,11 @@ This example demonstrates how to use GenSX's `gsx.execute` to execute sub-workfl
 # Install dependencies
 pnpm install
 
+# Set your OpenAI API key
+export OPENAI_API_KEY=<your_api_key>
+
 # Run the example
-OPENAI_API_KEY=<your_api_key> npm run run
+pnpm run start
 ```
 
 The example will clean a sample text containing business buzzwords. You can modify the input text in `index.tsx` to clean different content.

--- a/examples/reflection/package.json
+++ b/examples/reflection/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "dev": "nodemon",
-    "run": "NODE_OPTIONS='--enable-source-maps' tsx ./index.tsx",
+    "start": "NODE_OPTIONS='--enable-source-maps' tsx ./index.tsx",
     "build": "tsc",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",

--- a/examples/streaming/README.md
+++ b/examples/streaming/README.md
@@ -19,7 +19,7 @@ pnpm install
 export OPENAI_API_KEY=<your_api_key>
 
 # Run the example
-pnpm run run
+pnpm run start
 ```
 
 The example will run two versions of the same prompt:

--- a/examples/streaming/package.json
+++ b/examples/streaming/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "dev": "nodemon",
-    "run": "NODE_OPTIONS='--enable-source-maps' tsx ./index.tsx",
+    "start": "NODE_OPTIONS='--enable-source-maps' tsx ./index.tsx",
     "build": "tsc",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix"

--- a/examples/structuredOutputs/README.md
+++ b/examples/structuredOutputs/README.md
@@ -12,5 +12,5 @@ pnpm install
 export OPENAI_API_KEY=<your_api_key>
 
 # Run the example
-pnpm run run
+pnpm run start
 ```

--- a/examples/structuredOutputs/package.json
+++ b/examples/structuredOutputs/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "dev": "nodemon",
-    "run": "NODE_OPTIONS='--enable-source-maps' tsx ./index.tsx",
+    "start": "NODE_OPTIONS='--enable-source-maps' tsx ./index.tsx",
     "build": "tsc",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",


### PR DESCRIPTION
Updating all examples to use `start` instead of `run`. This aligns the examples with the output of `create gensx` and prevents the weirdness of `npm run run`