### PR TITLE
feat: Add `gsx.array` plus `map`, `filter`, `reduce`, and `flatMap`

### DIFF
--- a/packages/gensx/src/array.ts
+++ b/packages/gensx/src/array.ts
@@ -1,0 +1,68 @@
+import type { JSX } from "./jsx-runtime";
+
+import { execute } from "./resolve";
+
+export class GsxArray<T> {
+  private promise: Promise<unknown[]>;
+
+  constructor(items: JSX.Element[] | Promise<unknown[]>) {
+    this.promise = Promise.resolve(items);
+  }
+
+  map<U>(fn: (item: T) => JSX.Element): GsxArray<U> {
+    const mapped = this.promise
+      .then(items => execute<T[]>(items))
+      .then(resolvedItems => resolvedItems.map(fn));
+    return new GsxArray(mapped);
+  }
+
+  flatMap<U>(fn: (item: T) => JSX.Element): GsxArray<U> {
+    const mapped = this.promise
+      .then(items => execute<T[]>(items))
+      .then(async resolvedItems => {
+        const nestedResults = await Promise.all(
+          resolvedItems.map(async item => {
+            const result = await execute<U | U[]>(fn(item));
+            return Array.isArray(result) ? result : [result];
+          }),
+        );
+        return nestedResults.flat();
+      });
+    return new GsxArray(mapped);
+  }
+
+  filter(predicate: (item: T) => JSX.Element): GsxArray<T> {
+    const filtered = this.promise
+      .then(items => execute<T[]>(items))
+      .then(async resolvedItems => {
+        const results = await Promise.all(
+          resolvedItems.map(async item => ({
+            item,
+            keep: await execute<boolean>(predicate(item)),
+          })),
+        );
+        return results.filter(({ keep }) => keep).map(({ item }) => item);
+      });
+    return new GsxArray(filtered);
+  }
+
+  reduce<U>(fn: (acc: U, item: T) => JSX.Element, initial: U): Promise<U> {
+    return this.promise
+      .then(items => execute<T[]>(items))
+      .then(async resolvedItems => {
+        let result = initial;
+        for (const item of resolvedItems) {
+          result = await execute<U>(fn(result, item));
+        }
+        return result;
+      });
+  }
+
+  toArray(): Promise<T[]> {
+    return this.promise.then(items => execute<T[]>(items));
+  }
+}
+
+export function array<T>(items: JSX.Element[]): GsxArray<T> {
+  return new GsxArray(items);
+}

--- a/packages/gensx/src/index.ts
+++ b/packages/gensx/src/index.ts
@@ -3,6 +3,7 @@ export { execute } from "./resolve";
 export { Fragment, jsx, jsxs } from "./jsx-runtime";
 export type { JSX } from "./jsx-runtime";
 export { StreamComponent, Component } from "./component";
+export { array } from "./array";
 export type {
   Args,
   Context,
@@ -12,7 +13,9 @@ export type {
   GsxStreamComponent,
   GsxComponent,
 } from "./types";
+export type { GsxArray } from "./array";
 
+import { array } from "./array";
 import { Component, StreamComponent } from "./component";
 import { createContext, useContext } from "./context";
 import { execute } from "./resolve";
@@ -30,4 +33,5 @@ export const gsx = {
   createContext,
   execute,
   useContext,
+  array,
 };

--- a/packages/gensx/tests/array.test.tsx
+++ b/packages/gensx/tests/array.test.tsx
@@ -1,0 +1,115 @@
+import { expect, test } from "vitest";
+
+import { gsx } from "../src";
+
+interface NumberWrapperOutput {
+  value: number;
+}
+
+const NumberWrapper = gsx.Component<{ n: number }, NumberWrapperOutput>(
+  "NumberWrapper",
+  ({ n }) => ({ value: n }),
+);
+
+const NumberDoubler = gsx.Component<{ value: number }, number>(
+  "NumberDoubler",
+  ({ value }) => value * 2,
+);
+
+const AsyncNumberFilter = gsx.Component<{ value: number }, boolean>(
+  "AsyncNumberFilter",
+  async ({ value }) => {
+    await new Promise(resolve => setTimeout(resolve, 1));
+    return value > 5;
+  },
+);
+
+const Value = gsx.Component<{ value: number }, number>(
+  "Value",
+  ({ value }) => value,
+);
+
+const TaskGenerator = gsx.Component<{ value: number }, number[]>(
+  "TaskGenerator",
+  async ({ value }) => {
+    // Simulate a workflow step that generates multiple tasks
+    await new Promise(resolve => setTimeout(resolve, 1));
+    // For each input, generate [value, value*2] as sub-tasks
+    return [value, value * 2];
+  },
+);
+
+test("map transforms array elements", async () => {
+  const arr = gsx.array<NumberWrapperOutput>([
+    <NumberWrapper n={1} />,
+    <NumberWrapper n={2} />,
+    <NumberWrapper n={3} />,
+  ]);
+  const result = await arr
+    .map(n => <NumberDoubler value={n.value} />)
+    .toArray();
+
+  expect(result).toEqual([2, 4, 6]);
+});
+
+test("filter removes elements based on predicate", async () => {
+  const arr = gsx.array<NumberWrapperOutput>([
+    <NumberWrapper n={1} />,
+    <NumberWrapper n={2} />,
+    <NumberWrapper n={3} />,
+    <NumberWrapper n={4} />,
+    <NumberWrapper n={5} />,
+    <NumberWrapper n={6} />,
+  ]);
+  const result = await arr
+    .filter(n => <AsyncNumberFilter value={n.value} />)
+    .toArray();
+
+  expect(result).toEqual([{ value: 6 }]);
+});
+
+test("reduce accumulates results", async () => {
+  const arr = gsx.array<NumberWrapperOutput>([
+    <NumberWrapper n={1} />,
+    <NumberWrapper n={2} />,
+    <NumberWrapper n={3} />,
+  ]);
+  const result = await arr
+    .map<number>(n => <NumberDoubler value={n.value} />)
+    .map<number>(n => <Value value={n} />)
+    .reduce((acc: number, n: number) => <Value value={acc + n} />, 0);
+
+  expect(result).toEqual(12); // (1*2 + 2*2 + 3*2)
+});
+
+test("chains multiple operations", async () => {
+  const arr = gsx.array<NumberWrapperOutput>([
+    <NumberWrapper n={1} />,
+    <NumberWrapper n={2} />,
+    <NumberWrapper n={3} />,
+    <NumberWrapper n={4} />,
+    <NumberWrapper n={5} />,
+  ]);
+  const result = await arr
+    .map<number>(n => <NumberDoubler value={n.value} />)
+    .map<number>(n => <Value value={n} />)
+    .filter((n: number) => <AsyncNumberFilter value={n} />)
+    .reduce<number>((acc: number, n: number) => <Value value={acc + n} />, 0);
+
+  expect(result).toEqual(24); // (6 + 8 + 10) where all values > 5 are kept
+});
+
+test("flatMap generates multiple tasks from each input", async () => {
+  const arr = gsx.array<NumberWrapperOutput>([
+    <NumberWrapper n={1} />,
+    <NumberWrapper n={2} />,
+  ]);
+
+  const result = await arr
+    .flatMap(n => <TaskGenerator value={n.value} />)
+    .toArray();
+
+  // Each input n generates [n, n*2]
+  // So input [1, 2] becomes [1, 2, 2, 4]
+  expect(result).toEqual([1, 2, 2, 4]);
+});

--- a/packages/gensx/tests/array.test.tsx
+++ b/packages/gensx/tests/array.test.tsx
@@ -35,8 +35,27 @@ const TaskGenerator = gsx.Component<{ value: number }, number[]>(
     // Simulate a workflow step that generates multiple tasks
     await new Promise(resolve => setTimeout(resolve, 1));
     // For each input, generate [value, value*2] as sub-tasks
-    return [value, value * 2];
+    return [value, <NumberDoubler value={value} />];
   },
+);
+
+const BatchProcessor = gsx.Component<{ inputs: number[] }, number>(
+  "BatchProcessor",
+  async ({ inputs }) => {
+    // Create a new array workflow inside the component
+    const results = await gsx
+      .array<NumberWrapperOutput>(inputs.map(n => <NumberWrapper n={n} />))
+      .map<number>(n => <NumberDoubler value={n.value} />)
+      .filter(n => <AsyncNumberFilter value={n} />)
+      .reduce((acc: number, n: number) => <Value value={acc + n} />, 0);
+
+    return results;
+  },
+);
+
+const ArrayProvider = gsx.Component<{ inputs: number[] }, number[]>(
+  "ArrayProvider",
+  ({ inputs }) => inputs,
 );
 
 test("map transforms array elements", async () => {
@@ -99,7 +118,7 @@ test("chains multiple operations", async () => {
   expect(result).toEqual(24); // (6 + 8 + 10) where all values > 5 are kept
 });
 
-test("flatMap generates multiple tasks from each input", async () => {
+test("flatMap generates multiple tasks from each input, task generator returns nested components", async () => {
   const arr = gsx.array<NumberWrapperOutput>([
     <NumberWrapper n={1} />,
     <NumberWrapper n={2} />,
@@ -112,4 +131,29 @@ test("flatMap generates multiple tasks from each input", async () => {
   // Each input n generates [n, n*2]
   // So input [1, 2] becomes [1, 2, 2, 4]
   expect(result).toEqual([1, 2, 2, 4]);
+});
+
+test("components can use gsx.array internally for workflow composition", async () => {
+  const result = await gsx.execute(<BatchProcessor inputs={[1, 2, 3, 4, 5]} />);
+
+  // Only values that double to > 5 are kept (6, 8, 10)
+  expect(result).toEqual(24);
+});
+
+test("can use gsx.array operations in child functions", async () => {
+  const result = await gsx.execute(
+    <ArrayProvider inputs={[1, 2, 3, 4, 5]}>
+      {(numbers: number[]) =>
+        gsx
+          .array<NumberWrapperOutput>(numbers.map(n => <NumberWrapper n={n} />))
+          .map<number>(n => <NumberDoubler value={n.value} />)
+          .filter(n => <AsyncNumberFilter value={n} />)
+          .toArray()
+      }
+    </ArrayProvider>,
+  );
+
+  // After doubling [1,2,3,4,5] we get [2,4,6,8,10]
+  // After filtering > 5 we get [6,8,10]
+  expect(result).toEqual([6, 8, 10]);
 });


### PR DESCRIPTION
Adds a new `gsx.array` wrapper that exposes a fluent API for array operations over array elements that may contain components that need to be executed before execution. 

Fixes https://github.com/cortexclick/gensx/issues/150 fixes https://github.com/cortexclick/gensx/issues/107

Due to typescript type limitations, many of these methods do require a generic parameter that maps to the operations output type. Something we can fix up in the future via compiler extensions and IDE integration. 

An example: 

```tsx
  const arr = gsx.array<NumberWrapperOutput>([
    <NumberWrapper n={1} />,
    <NumberWrapper n={2} />,
    <NumberWrapper n={3} />,
    <NumberWrapper n={4} />,
    <NumberWrapper n={5} />,
  ]);
  const result = await arr
    .map<number>(n => <NumberDoubler value={n.value} />)
    .map<number>(n => <Value value={n} />)
    .filter((n: number) => <AsyncNumberFilter value={n} />)
    .reduce<number>((acc: number, n: number) => acc + n />, 0);
```