### PR TITLE
docs: adding docs and example on providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,18 +113,19 @@ This repo contains a number of [examples](./examples) to help you get up and run
 
 ### Basic Examples
 
-| Example                                      | Description                                               |
-| -------------------------------------------- | --------------------------------------------------------- |
-| 📊 [Structured Outputs](./structuredOutputs) | Demonstrates using structured outputs with GenSX          |
-| 🔄 [Reflection](./reflection)                | Shows how to use a self-reflection pattern with GenSX     |
-| 🌊 [Streaming](./streaming)                  | Demonstrates how to handle streaming responses with GenSX |
+| Example                                               | Description                                           |
+| ----------------------------------------------------- | ----------------------------------------------------- |
+| 📊 [Structured Outputs](./examples/structuredOutputs) | Shows how to use structured outputs with GenSX        |
+| 🔄 [Reflection](./examples/reflection)                | Shows how to use a self-reflection pattern with GenSX |
+| 🌊 [Streaming](./examples/streaming)                  | Shows how to handle streaming responses with GenSX    |
+| 🔌 [Providers](./examples/providers)                  | Shows how to create a custom provider for GenSX       |
 
 ### Full Examples
 
-| Example                                         | Description                                                                                  |
-| ----------------------------------------------- | -------------------------------------------------------------------------------------------- |
-| 🔍 [Hacker News Analyzer](./hackerNewsAnalyzer) | Analyzes HN posts and generates summaries and trends using Paul Graham's writing style       |
-| ✍️ [Blog Writer](./blogWriter)                  | Generates blogs through an end-to-end workflow including topic research and content creation |
+| Example                                                  | Description                                                                                  |
+| -------------------------------------------------------- | -------------------------------------------------------------------------------------------- |
+| 🔍 [Hacker News Analyzer](./examples/hackerNewsAnalyzer) | Analyzes HN posts and generates summaries and trends using Paul Graham's writing style       |
+| ✍️ [Blog Writer](./examples/blogWriter)                  | Generates blogs through an end-to-end workflow including topic research and content creation |
 
 ## Working with this repo
 

--- a/docs/src/content/docs/basic-concepts.mdx
+++ b/docs/src/content/docs/basic-concepts.mdx
@@ -197,9 +197,4 @@ const result = await gsx.execute(
 );
 ```
 
-Providers offer several benefits:
-
-- Manage complex configuration like API clients and settings
-- Provide a simpler, more focused API than raw contexts
-- Keep configuration separate from business logic
-- Enable dependency injection for testing and development
+For more details on providers, see the [Providers](../concepts/providers) page.

--- a/docs/src/content/docs/concepts/providers.mdx
+++ b/docs/src/content/docs/concepts/providers.mdx
@@ -1,14 +1,96 @@
 ---
 title: Providers
-description: GenSX architecture and design goals
+description: Learn how to manage API keys and configuration dependencies in GenSX using providers
 sidebar:
   order: 3
 ---
 
-GenSX is a simple framework for building complex generative AI and LLM workflows.
+Providers are a specialized use of [contexts](../contexts) that focus on managing configuration and dependencies for your workflow. They're built using the context system, but provide a more focused API for configuration management.
 
-It uses `jsx` to define and orchestrate workflows with functional, reusable components:
+The main provider available today is the `OpenAIProvider`, which manages your OpenAI API key and client:
 
 ```tsx
+const result = await gsx.execute(
+  <OpenAIProvider apiKey={process.env.OPENAI_API_KEY}>
+    <ChatCompletion
+      model="gpt-4o-mini"
+      messages={[{ role: "user", content: "Hello!" }]}
+    />
+  </OpenAIProvider>,
+);
+```
 
+Providers offer several benefits:
+
+- **Centralized Configuration Management** - providers manage settings like API keys and feature flags keeping configuration separate from business logic.
+- **Data Sharing** - providers give you an easy way to share data between components without prop drilling to simplify your code.
+- **Reusability** - providers and their associated components can easily be reused in different parts of your application.
+- **Scoped State Management** - providers can be used to manage state for parts of your workflow or the entire thing.
+
+## Creating a Provider
+
+If you want to use a provide that isn't available out of the box, you can easily create your own. The example below shows how to create a provider for the [Firecrawl](https://www.firecrawl.dev/) API.
+
+Start by importing `gsx` and the package you want to use:
+
+```tsx
+import { gsx } from "gensx";
+import FirecrawlApp, { FirecrawlAppConfig } from "@mendable/firecrawl-js";
+```
+
+Next, create a context and then the provider:
+
+```tsx
+// Create a context
+export const FirecrawlContext = gsx.createContext<{
+  client?: FirecrawlApp;
+}>({});
+
+// Create the provider
+export const FirecrawlProvider = gsx.Component<FirecrawlAppConfig, never>(
+  "FirecrawlProvider",
+  (args: FirecrawlAppConfig) => {
+    const client = new FirecrawlApp({
+      apiKey: args.apiKey,
+    });
+    return <FirecrawlContext.Provider value={{ client }} />;
+  },
+);
+```
+
+Finally, you can build components that use the provider.
+
+```tsx
+export const ScrapePage = gsx.Component<ScrapePageProps, string>(
+  "ScrapePage",
+  async ({ url }) => {
+    const context = gsx.useContext(FirecrawlContext);
+
+    if (!context.client) {
+      throw new Error(
+        "Firecrawl client not found. Please wrap your component with FirecrawlProvider.",
+      );
+    }
+    const result = await context.client.scrapeUrl(url, {
+      formats: ["markdown"],
+      timeout: 30000,
+    });
+
+    if (!result.success || !result.markdown) {
+      throw new Error(`Failed to scrape url: ${url}`);
+    }
+
+    return result.markdown;
+  },
+);
+```
+
+To use the `FirecrawlProvider` and `ScrapePage` component, you would then do the following:
+
+```tsx
+const markdown = await gsx.execute(
+  <FirecrawlProvider apiKey={process.env.FIRECRAWL_API_KEY}>
+    <ScrapePage url="https://gensx.dev/overview/" />
+  </FirecrawlProvider>,
+);
 ```

--- a/examples/README.md
+++ b/examples/README.md
@@ -29,6 +29,7 @@ Make sure to check what environment variables are required for each example.
 | 📊 [Structured Outputs](./structuredOutputs) | Demonstrates using structured outputs with GenSX          |
 | 🔄 [Reflection](./reflection)                | Shows how to use a self-reflection pattern with GenSX     |
 | 🌊 [Streaming](./streaming)                  | Demonstrates how to handle streaming responses with GenSX |
+| 🔌 [Providers](./providers)                  | Shows how to create a custom provider for GenSX           |
 
 ## Full Examples
 

--- a/examples/blogWriter/package.json
+++ b/examples/blogWriter/package.json
@@ -11,8 +11,7 @@
     "start": "NODE_OPTIONS='--enable-source-maps' tsx ./index.tsx",
     "build": "tsc",
     "lint": "eslint .",
-    "lint:fix": "eslint . --fix",
-    "test": "NODE_OPTIONS='--enable-source-maps' tsx ./index.tsx"
+    "lint:fix": "eslint . --fix"
   },
   "dependencies": {
     "@gensx/openai": "workspace:*",

--- a/examples/hackerNewsAnalyzer/package.json
+++ b/examples/hackerNewsAnalyzer/package.json
@@ -11,8 +11,7 @@
     "start": "NODE_OPTIONS='--enable-source-maps' tsx ./index.tsx",
     "build": "tsc",
     "lint": "eslint .",
-    "lint:fix": "eslint . --fix",
-    "test": "NODE_OPTIONS='--enable-source-maps' tsx ./index.tsx"
+    "lint:fix": "eslint . --fix"
   },
   "dependencies": {
     "@gensx/openai": "workspace:*",

--- a/examples/providers/README.md
+++ b/examples/providers/README.md
@@ -1,16 +1,8 @@
-# Reflection Example
+# Providers Example
 
-This example demonstrates how to use GenSX's `gsx.execute` to execute sub-workflows, as well as recursive component execution. It implements a buzzword cleaning system that uses GPT to iteratively remove business jargon while preserving the original meaning of the text.
+This example shows how to create a provider and a related component. In particular, it creates a provider for the [Firecrawl](https://www.firecrawl.dev/) API and uses it to scrape a page and return the markdown.
 
-## What it demonstrates
-
-- Recursive component implementation using `gsx.execute`
-- Integration with OpenAI's GPT model
-- State management through component props
-- Complex workflow with multiple steps:
-  1. Buzzword detection
-  2. Text cleaning via GPT
-  3. Recursive verification
+For more details on providers, see the [Providers](https://gensx.dev/concepts/providers) page.
 
 ## Usage
 
@@ -18,11 +10,11 @@ This example demonstrates how to use GenSX's `gsx.execute` to execute sub-workfl
 # Install dependencies
 pnpm install
 
-# Set your OpenAI API key
-export OPENAI_API_KEY=<your_api_key>
+# Set your Firecrawl API key
+export FIRECRAWL_API_KEY=<your_api_key>
 
 # Run the example
 pnpm run start
 ```
 
-The example will clean a sample text containing business buzzwords. You can modify the input text in `index.tsx` to clean different content.
+When you run the example, it will scrape the page at `https://gensx.dev/overview/` and return the markdown.

--- a/examples/providers/README.md
+++ b/examples/providers/README.md
@@ -1,0 +1,28 @@
+# Reflection Example
+
+This example demonstrates how to use GenSX's `gsx.execute` to execute sub-workflows, as well as recursive component execution. It implements a buzzword cleaning system that uses GPT to iteratively remove business jargon while preserving the original meaning of the text.
+
+## What it demonstrates
+
+- Recursive component implementation using `gsx.execute`
+- Integration with OpenAI's GPT model
+- State management through component props
+- Complex workflow with multiple steps:
+  1. Buzzword detection
+  2. Text cleaning via GPT
+  3. Recursive verification
+
+## Usage
+
+```bash
+# Install dependencies
+pnpm install
+
+# Set your OpenAI API key
+export OPENAI_API_KEY=<your_api_key>
+
+# Run the example
+pnpm run start
+```
+
+The example will clean a sample text containing business buzzwords. You can modify the input text in `index.tsx` to clean different content.

--- a/examples/providers/eslint.config.mjs
+++ b/examples/providers/eslint.config.mjs
@@ -1,0 +1,22 @@
+import rootConfig from "../../eslint.config.mjs";
+
+export default [
+  ...rootConfig,
+  {
+    files: ["**/*.{js,mjs,cjs,jsx,ts,tsx}"],
+    languageOptions: {
+      parserOptions: {
+        tsconfigRootDir: import.meta.dirname,
+        project: "./tsconfig.json",
+      },
+    },
+    rules: {
+      "@typescript-eslint/no-unsafe-assignment": "off",
+      "@typescript-eslint/no-unsafe-call": "off",
+      "@typescript-eslint/no-unsafe-member-access": "off",
+      "@typescript-eslint/no-unsafe-return": "off",
+      "@typescript-eslint/no-unsafe-argument": "off",
+      "node/no-unsupported-features/es-syntax": "off",
+    },
+  },
+];

--- a/examples/providers/firecrawlProvider.tsx
+++ b/examples/providers/firecrawlProvider.tsx
@@ -1,0 +1,46 @@
+import FirecrawlApp, { FirecrawlAppConfig } from "@mendable/firecrawl-js";
+import { gsx } from "gensx";
+
+// Create a context
+export const FirecrawlContext = gsx.createContext<{
+  client?: FirecrawlApp;
+}>({});
+
+// Create the provider
+export const FirecrawlProvider = gsx.Component<FirecrawlAppConfig, never>(
+  "FirecrawlProvider",
+  (args: FirecrawlAppConfig) => {
+    const client = new FirecrawlApp({
+      apiKey: args.apiKey,
+    });
+    return <FirecrawlContext.Provider value={{ client }} />;
+  },
+);
+
+interface ScrapePageProps {
+  url: string;
+}
+
+// Create a component that uses the provider
+export const ScrapePage = gsx.Component<ScrapePageProps, string>(
+  "ScrapePage",
+  async ({ url }) => {
+    const context = gsx.useContext(FirecrawlContext);
+
+    if (!context.client) {
+      throw new Error(
+        "Firecrawl client not found. Please wrap your component with FirecrawlProvider.",
+      );
+    }
+    const result = await context.client.scrapeUrl(url, {
+      formats: ["markdown"],
+      timeout: 30000,
+    });
+
+    if (!result.success || !result.markdown) {
+      throw new Error(`Failed to scrape url: ${url}`);
+    }
+
+    return result.markdown;
+  },
+);

--- a/examples/providers/index.tsx
+++ b/examples/providers/index.tsx
@@ -1,0 +1,18 @@
+import { gsx } from "gensx";
+
+import { FirecrawlProvider, ScrapePage } from "./firecrawlProvider.js";
+
+async function main() {
+  const url = "https://gensx.dev/overview/";
+
+  console.log("\n🚀 Scraping page from url:", url);
+  const markdown = await gsx.execute<string>(
+    <FirecrawlProvider apiKey={process.env.FIRECRAWL_API_KEY}>
+      <ScrapePage url={url} />
+    </FirecrawlProvider>,
+  );
+  console.log("\n✅ Scraping complete");
+  console.log("\n🚀 Scraped markdown:", markdown);
+}
+
+main().catch(console.error);

--- a/examples/providers/nodemon.json
+++ b/examples/providers/nodemon.json
@@ -1,0 +1,5 @@
+{
+  "watch": [".", ".env", "../../packages/**/dist/**"],
+  "exec": "NODE_OPTIONS='--enable-source-maps' tsx --inspect=0.0.0.0:9229 ./index.tsx",
+  "ext": "ts, tsx, js, json"
+}

--- a/examples/providers/package.json
+++ b/examples/providers/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@gensx-examples/providers",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "engines": {
+    "node": ">=18.0.0"
+  },
+  "scripts": {
+    "dev": "nodemon",
+    "start": "NODE_OPTIONS='--enable-source-maps' tsx ./index.tsx",
+    "build": "tsc",
+    "lint": "eslint .",
+    "lint:fix": "eslint . --fix",
+    "test": "NODE_OPTIONS='--enable-source-maps' tsx ./index.tsx"
+  },
+  "dependencies": {
+    "@gensx/openai": "workspace:*",
+    "@mendable/firecrawl-js": "^1.15.7",
+    "gensx": "workspace:*",
+    "openai": "^4.77.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20.17.11",
+    "nodemon": "^3.1.9",
+    "tsx": "^4.19.2",
+    "typescript": "^5.0.0"
+  }
+}

--- a/examples/providers/package.json
+++ b/examples/providers/package.json
@@ -11,8 +11,7 @@
     "start": "NODE_OPTIONS='--enable-source-maps' tsx ./index.tsx",
     "build": "tsc",
     "lint": "eslint .",
-    "lint:fix": "eslint . --fix",
-    "test": "NODE_OPTIONS='--enable-source-maps' tsx ./index.tsx"
+    "lint:fix": "eslint . --fix"
   },
   "dependencies": {
     "@gensx/openai": "workspace:*",

--- a/examples/providers/tsconfig.json
+++ b/examples/providers/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "NodeNext",
+    "lib": ["ESNext", "DOM"],
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "moduleResolution": "NodeNext",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "react-jsx",
+    "jsxImportSource": "gensx",
+    "outDir": "./dist"
+  },
+  "include": ["./*.ts", "./*.tsx", "./**/*.ts", "./**/*.tsx"],
+  "exclude": ["node_modules"]
+}

--- a/examples/reflection/package.json
+++ b/examples/reflection/package.json
@@ -11,8 +11,7 @@
     "start": "NODE_OPTIONS='--enable-source-maps' tsx ./index.tsx",
     "build": "tsc",
     "lint": "eslint .",
-    "lint:fix": "eslint . --fix",
-    "test": "NODE_OPTIONS='--enable-source-maps' tsx ./index.tsx"
+    "lint:fix": "eslint . --fix"
   },
   "dependencies": {
     "@gensx/openai": "workspace:*",

--- a/examples/structuredOutputs/package.json
+++ b/examples/structuredOutputs/package.json
@@ -11,8 +11,7 @@
     "start": "NODE_OPTIONS='--enable-source-maps' tsx ./index.tsx",
     "build": "tsc",
     "lint": "eslint .",
-    "lint:fix": "eslint . --fix",
-    "test": "NODE_OPTIONS='--enable-source-maps' tsx ./index.tsx"
+    "lint:fix": "eslint . --fix"
   },
   "dependencies": {
     "@gensx/openai": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -135,6 +135,34 @@ importers:
         specifier: ^5.0.0
         version: 5.7.2
 
+  examples/providers:
+    dependencies:
+      '@gensx/openai':
+        specifier: workspace:*
+        version: link:../../packages/gensx-openai
+      '@mendable/firecrawl-js':
+        specifier: ^1.15.7
+        version: 1.15.7(ws@8.18.0)
+      gensx:
+        specifier: workspace:*
+        version: link:../../packages/gensx
+      openai:
+        specifier: ^4.77.0
+        version: 4.77.4(zod@3.24.1)
+    devDependencies:
+      '@types/node':
+        specifier: ^20.17.11
+        version: 20.17.11
+      nodemon:
+        specifier: ^3.1.9
+        version: 3.1.9
+      tsx:
+        specifier: ^4.19.2
+        version: 4.19.2
+      typescript:
+        specifier: ^5.0.0
+        version: 5.7.2
+
   examples/reflection:
     dependencies:
       '@gensx/openai':
@@ -1328,6 +1356,9 @@ packages:
   '@mdx-js/mdx@3.1.0':
     resolution: {integrity: sha512-/QxEhPAvGwbQmy1Px8F899L5Uc2KZ6JtXwlCgJmjSTBedwOZkByYcBG4GceIGPXRDsmfxhHazuS+hlOShRLeDw==}
 
+  '@mendable/firecrawl-js@1.15.7':
+    resolution: {integrity: sha512-avCwLyzEtrD/D+gchvmbrlThRyeqVXozVGMalDlCnb3cBfm6iRv99PbiZNu/vy6I+kuz/lbxCMewnVPbCr4VCw==}
+
   '@microsoft/api-extractor-model@7.28.13':
     resolution: {integrity: sha512-39v/JyldX4MS9uzHcdfmjjfS6cYGAoXV+io8B5a338pkHiSt+gy2eXQ0Q7cGFJ7quSa1VqqlMdlPrB6sLR/cAw==}
 
@@ -2040,6 +2071,9 @@ packages:
     peerDependencies:
       postcss: ^8.1.0
 
+  axios@1.7.9:
+    resolution: {integrity: sha512-LhLcE7Hbiryz8oMDdDptSrWowmB4Bl6RCt6sIJKpRB4XtVf0iEgewX3au/pJqm+Py1kCASkb/FFKjxQaLtxJvw==}
+
   axobject-query@4.1.0:
     resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
     engines: {node: '>= 0.4'}
@@ -2626,6 +2660,15 @@ packages:
     resolution: {integrity: sha512-9UbaD6XdAL97+k/n+N7JwX46K/M6Zc6KcFYskrYL8wbBV/Uyk0CTAMY0VT+qiK5PM7AIc9aTWYtq65U7T+aCNQ==}
     engines: {node: '>=8'}
 
+  follow-redirects@1.15.9:
+    resolution: {integrity: sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==}
+    engines: {node: '>=4.0'}
+    peerDependencies:
+      debug: '*'
+    peerDependenciesMeta:
+      debug:
+        optional: true
+
   foreground-child@3.3.0:
     resolution: {integrity: sha512-Ld2g8rrAyMYFXBhEqMz8ZAHBi4J4uS1i/CxGMDnjyFWddMXLVcDp051DZfu+t7+ab7Wv6SMqpWmyFIj5UbfFvg==}
     engines: {node: '>=14'}
@@ -2930,6 +2973,11 @@ packages:
 
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
+  isows@1.0.6:
+    resolution: {integrity: sha512-lPHCayd40oW98/I0uvgaHKWCSvkzY27LjWLbtzOm64yQ+G3Q5npjjbdppU65iZXkK1Zt+kH9pfegli0AYfwYYw==}
+    peerDependencies:
+      ws: '*'
 
   istanbul-lib-coverage@3.2.2:
     resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
@@ -3635,6 +3683,9 @@ packages:
   property-information@6.5.0:
     resolution: {integrity: sha512-PgTgs/BlvHxOu8QuEN7wi5A0OmXaBcHpmCSTehcs6Uuu9IkDIEo13Hy7n898RHfrQ49vKCoGeWZSaAK01nwVig==}
 
+  proxy-from-env@1.1.0:
+    resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
+
   pstree.remy@1.1.8:
     resolution: {integrity: sha512-77DZwxQmxKnu3aR542U+X8FypNzbfJ+C5XQDk3uWjWxn6151aIMGthWYRXTqT1E5oJvg+ljaa2OJi+VfvCOQ8w==}
 
@@ -4116,6 +4167,9 @@ packages:
   type-fest@4.31.0:
     resolution: {integrity: sha512-yCxltHW07Nkhv/1F6wWBr8kz+5BGMfP+RbRSYFnegVb0qV/UMT0G0ElBloPVerqn4M2ZV80Ir1FtCcYv1cT6vQ==}
     engines: {node: '>=16'}
+
+  typescript-event-target@1.1.1:
+    resolution: {integrity: sha512-dFSOFBKV6uwaloBCCUhxlD3Pr/P1a/tJdcmPrTXCHlEFD3faj0mztjcGn6VBAhQ0/Bdy8K3VWrrqwbt/ffsYsg==}
 
   typescript@5.4.2:
     resolution: {integrity: sha512-+2/g0Fds1ERlP6JsakQQDXjZdZMM+rqpamFZJEKh4kwTIn3iDkgKtby0CeNd5ATNZ4Ry1ax15TMx0W2V+miizQ==}
@@ -5585,6 +5639,17 @@ snapshots:
       - acorn
       - supports-color
 
+  '@mendable/firecrawl-js@1.15.7(ws@8.18.0)':
+    dependencies:
+      axios: 1.7.9
+      isows: 1.0.6(ws@8.18.0)
+      typescript-event-target: 1.1.1
+      zod: 3.24.1
+      zod-to-json-schema: 3.24.1(zod@3.24.1)
+    transitivePeerDependencies:
+      - debug
+      - ws
+
   '@microsoft/api-extractor-model@7.28.13(@types/node@22.10.5)':
     dependencies:
       '@microsoft/tsdoc': 0.14.2
@@ -6485,6 +6550,14 @@ snapshots:
       postcss: 8.4.49
       postcss-value-parser: 4.2.0
 
+  axios@1.7.9:
+    dependencies:
+      follow-redirects: 1.15.9
+      form-data: 4.0.1
+      proxy-from-env: 1.1.0
+    transitivePeerDependencies:
+      - debug
+
   axobject-query@4.1.0: {}
 
   bail@2.0.2: {}
@@ -7131,6 +7204,8 @@ snapshots:
 
   flattie@1.1.1: {}
 
+  follow-redirects@1.15.9: {}
+
   foreground-child@3.3.0:
     dependencies:
       cross-spawn: 7.0.6
@@ -7542,6 +7617,10 @@ snapshots:
       is-inside-container: 1.0.0
 
   isexe@2.0.0: {}
+
+  isows@1.0.6(ws@8.18.0):
+    dependencies:
+      ws: 8.18.0
 
   istanbul-lib-coverage@3.2.2: {}
 
@@ -8528,6 +8607,8 @@ snapshots:
 
   property-information@6.5.0: {}
 
+  proxy-from-env@1.1.0: {}
+
   pstree.remy@1.1.8: {}
 
   punycode@2.3.1: {}
@@ -9128,6 +9209,8 @@ snapshots:
   type-fest@0.20.2: {}
 
   type-fest@4.31.0: {}
+
+  typescript-event-target@1.1.1: {}
 
   typescript@5.4.2: {}
 


### PR DESCRIPTION
Recreating #148 from a clean branch


Adds the concept doc for providers

Also adds a provider example that shows how to create a provider for Firecrawl (that is discussed in the doc)

It's worth noting that the top of this doc is the same as the text from the basic concepts page but it extends the info. Eventually we will also want an "Available Providers" section but when written currently, it only contains the OpenAIProvider.