### PR TITLE
fix: Fix checkpoint race condition by handling out of order arrival of nodes

### DIFF
--- a/packages/gensx/src/checkpoint.ts
+++ b/packages/gensx/src/checkpoint.ts
@@ -106,15 +106,52 @@ export class CheckpointManager implements CheckpointWriter {
     }, 5000);
   }
 
-  // updateCheckpoint POSTs the current component tree to the GenSX API.
-  // Special care is taken to do this in a non-blocking manner, and in a way that
-  // minimizes chattiness with the server.
-  // We only write one checkpoint at a time. If another checkpoint comes in while
-  // we're still processing, we just mark that we need another update and return.
-  // When the current checkpoint write is complete, we check if there was a pending
-  // update request, and if so, we trigger another write.
+  /**
+   * Validates that the execution tree is in a complete state where:
+   * 1. Root node exists
+   * 2. No orphaned nodes are waiting for parents
+   * 3. All parent-child relationships are properly connected
+   */
+  private isTreeValid(): boolean {
+    // No root means tree isn't valid
+    if (!this.root) return false;
+
+    // If we have orphaned nodes, tree isn't complete
+    if (this.orphanedNodes.size > 0) return false;
+
+    // Verify all nodes in the tree have their parents
+    const verifyNode = (node: ExecutionNode): boolean => {
+      for (const child of node.children) {
+        if (child.parentId !== node.id) return false;
+        if (!verifyNode(child)) return false;
+      }
+      return true;
+    };
+
+    return verifyNode(this.root);
+  }
+
+  /**
+   * Updates the checkpoint in a non-blocking manner while ensuring consistency.
+   * Special care is taken to:
+   * 1. Queue updates instead of writing immediately to minimize API calls
+   * 2. Only write one checkpoint at a time to maintain order
+   * 3. Track pending updates to ensure no state is lost
+   * 4. Validate tree completeness before writing
+   *
+   * The flow is:
+   * 1. If a write is in progress, mark pendingUpdate = true
+   * 2. When write completes, check pendingUpdate and trigger another write if needed
+   * 3. Only write if tree is valid (has root and no orphans)
+   */
   private updateCheckpoint() {
-    if (!this.checkpointsEnabled || !this.root) {
+    if (!this.checkpointsEnabled) {
+      return;
+    }
+
+    // Only write if we have a valid tree
+    if (!this.isTreeValid()) {
+      this.pendingUpdate = true;
       return;
     }
 
@@ -163,6 +200,33 @@ export class CheckpointManager implements CheckpointWriter {
     }
   }
 
+  /**
+   * Due to the async nature of component execution, nodes can arrive in any order.
+   * For example, in a tree like:
+   *    BlogWriter
+   *      └─ OpenAIProvider
+   *         └─ Research
+   *
+   * The Research component might execute before OpenAIProvider due to:
+   * - Parallel execution of components
+   * - Different resolution times for promises
+   * - Network delays in API calls
+   *
+   * To handle this, we:
+   * 1. Track orphaned nodes (children with parentIds where parents aren't yet in the graph) because:
+   *    - We need to maintain the true hierarchy regardless of arrival order
+   *    - We can't write incomplete checkpoints that would show incorrect relationships
+   *    - The tree structure is important for debugging and monitoring
+   *
+   * 2. Allow root replacement because:
+   *    - The first node to arrive might not be the true root
+   *    - We need to maintain correct component hierarchy for visualization
+   *    - Checkpoint consumers expect a complete, properly ordered tree
+   *
+   * This approach ensures that even if components resolve out of order,
+   * the final checkpoint will always show the correct logical structure
+   * of the execution.
+   */
   addNode(partialNode: Partial<ExecutionNode>, parentId?: string): string {
     const nodeId = generateUUID();
     const node: ExecutionNode = {

--- a/packages/gensx/src/checkpoint.ts
+++ b/packages/gensx/src/checkpoint.ts
@@ -3,7 +3,6 @@ import { join } from "node:path";
 // Cross-platform UUID generation
 function generateUUID(): string {
   try {
-    // Try Node.js crypto first
     const crypto = globalThis.crypto;
     return crypto.randomUUID();
   } catch {

--- a/packages/gensx/src/component.ts
+++ b/packages/gensx/src/component.ts
@@ -20,8 +20,7 @@ export function Component<P, O>(
     const { checkpointManager } = workflowContext;
 
     // Create checkpoint node for this component execution
-    // only async due to dynamic import, but otherwise non-blocking
-    const nodeId = await checkpointManager.addNode(
+    const nodeId = checkpointManager.addNode(
       {
         componentName: name,
         props: Object.fromEntries(
@@ -69,7 +68,7 @@ export function StreamComponent<P>(
     const { checkpointManager } = workflowContext;
 
     // Create checkpoint node for this component execution
-    const nodeId = await checkpointManager.addNode(
+    const nodeId = checkpointManager.addNode(
       {
         componentName: name,
         props: Object.fromEntries(

--- a/packages/gensx/tests/checkpoint.test.tsx
+++ b/packages/gensx/tests/checkpoint.test.tsx
@@ -72,7 +72,7 @@ suite("checkpoint", () => {
     // Mock fetch for all tests
     global.fetch = vi
       .fn()
-      .mockImplementation(async (_input: FetchInput, _options?: FetchInit) => {
+      .mockImplementation((_input: FetchInput, _options?: FetchInit) => {
         return new Response(null, { status: 200 });
       });
   });

--- a/packages/gensx/tests/checkpoint.test.tsx
+++ b/packages/gensx/tests/checkpoint.test.tsx
@@ -14,6 +14,11 @@ import { createWorkflowContext } from "@/workflow-context.js";
 type FetchInput = Parameters<typeof fetch>[0];
 type FetchInit = Parameters<typeof fetch>[1];
 
+// Helper function to generate test IDs
+function generateTestId(): string {
+  return `test-${Math.random().toString(36).substring(7)}`;
+}
+
 /**
  * Helper to execute a workflow with checkpoint tracking
  * Returns both the execution result and recorded checkpoints for verification
@@ -64,6 +69,12 @@ suite("checkpoint", () => {
 
   beforeEach(() => {
     process.env.GENSX_CHECKPOINTS = "true";
+    // Mock fetch for all tests
+    global.fetch = vi
+      .fn()
+      .mockImplementation(async (_input: FetchInput, _options?: FetchInit) => {
+        return new Response(null, { status: 200 });
+      });
   });
 
   afterEach(() => {
@@ -361,6 +372,111 @@ suite("checkpoint", () => {
         },
       ],
     });
+  });
+
+  test("handles out of order node insertion and tree reconstruction", () => {
+    // Test case 1: Simple parent-child relationship
+    const cm1 = new CheckpointManager();
+    const parentId = generateTestId();
+    const child1Id = cm1.addNode({ componentName: "Child1" }, parentId);
+    cm1.addNode({ componentName: "Parent", id: parentId });
+
+    // Verify fetch was called with the correct tree structure
+    const fetchMock = global.fetch as unknown as ReturnType<typeof vi.fn>;
+    expect(fetchMock).toHaveBeenCalled();
+    const lastCall = fetchMock.mock.lastCall;
+    expect(lastCall).toBeDefined();
+    const options = lastCall![1] as FetchInit;
+    expect(options?.body).toBeDefined();
+    const lastCallBody = JSON.parse(options!.body! as string) as ExecutionNode;
+    expect(lastCallBody.componentName).toBe("Parent");
+    expect(lastCallBody.children[0].componentName).toBe("Child1");
+
+    // Rest of test case 1 assertions
+    expect(cm1.root?.componentName).toBe("Parent");
+    expect(cm1.root?.children).toHaveLength(1);
+    expect(cm1.root?.children[0].componentName).toBe("Child1");
+    expect(cm1.root?.children[0].id).toBe(child1Id);
+
+    // Test case 2: Multiple children waiting for same parent
+    const cm2 = new CheckpointManager();
+    const parent2Id = generateTestId();
+    cm2.addNode({ componentName: "Child2A" }, parent2Id);
+    cm2.addNode({ componentName: "Child2B" }, parent2Id);
+    cm2.addNode({ componentName: "Parent2", id: parent2Id });
+
+    expect(cm2.root?.componentName).toBe("Parent2");
+    expect(cm2.root?.children).toHaveLength(2);
+    expect(cm2.root?.children.map(c => c.componentName)).toContain("Child2A");
+    expect(cm2.root?.children.map(c => c.componentName)).toContain("Child2B");
+
+    // Test case 3: Deep tree with mixed ordering
+    const cm3 = new CheckpointManager();
+    const root3Id = generateTestId();
+    const branch3aId = generateTestId();
+    const branch3bId = generateTestId();
+
+    cm3.addNode({ componentName: "Leaf3A" }, branch3aId);
+    cm3.addNode({ componentName: "Leaf3B" }, branch3bId);
+    cm3.addNode({ componentName: "Root3", id: root3Id });
+    cm3.addNode({ componentName: "Branch3A", id: branch3aId }, root3Id);
+    cm3.addNode({ componentName: "Branch3B", id: branch3bId }, root3Id);
+
+    const root3 = cm3.root;
+    expect(root3?.componentName).toBe("Root3");
+    expect(root3?.children).toHaveLength(2);
+
+    const branch3a = root3?.children.find(c => c.componentName === "Branch3A");
+    const branch3b = root3?.children.find(c => c.componentName === "Branch3B");
+
+    expect(branch3a?.children[0].componentName).toBe("Leaf3A");
+    expect(branch3b?.children[0].componentName).toBe("Leaf3B");
+
+    // Test case 4: Root node arrives after its children
+    const cm4 = new CheckpointManager();
+    const root4Id = generateTestId();
+    const child4Id = cm4.addNode({ componentName: "Child4" }, root4Id);
+    cm4.addNode({ componentName: "Grandchild4" }, child4Id);
+    cm4.addNode({ componentName: "Root4", id: root4Id });
+
+    expect(cm4.root?.componentName).toBe("Root4");
+    expect(cm4.root?.children[0].componentName).toBe("Child4");
+    expect(cm4.root?.children[0].children[0].componentName).toBe("Grandchild4");
+
+    // Test case 5: Complex reordering with multiple levels
+    const cm5 = new CheckpointManager();
+    const root5Id = generateTestId();
+    const branch5aId = generateTestId();
+    const branch5bId = generateTestId();
+
+    cm5.addNode({ componentName: "Leaf5A" }, branch5aId);
+    cm5.addNode({ componentName: "Leaf5B" }, branch5bId);
+    cm5.addNode({ componentName: "Leaf5C" }, branch5aId);
+
+    cm5.addNode({ componentName: "Branch5B", id: branch5bId }, root5Id);
+    cm5.addNode({ componentName: "Root5", id: root5Id });
+    cm5.addNode({ componentName: "Branch5A", id: branch5aId }, root5Id);
+
+    const root5 = cm5.root;
+    expect(root5?.componentName).toBe("Root5");
+    expect(root5?.children).toHaveLength(2);
+
+    const branch5a = root5?.children.find(c => c.componentName === "Branch5A");
+    const branch5b = root5?.children.find(c => c.componentName === "Branch5B");
+
+    // Verify all nodes are connected properly
+    expect(branch5a?.children.map(c => c.componentName)).toContain("Leaf5A");
+    expect(branch5a?.children.map(c => c.componentName)).toContain("Leaf5C");
+    expect(branch5b?.children.map(c => c.componentName)).toContain("Leaf5B");
+
+    // Verify tree integrity - every node should have correct parent reference
+    function verifyNodeParentRefs(node: ExecutionNode) {
+      for (const child of node.children) {
+        expect(child.parentId).toBe(node.id);
+        verifyNodeParentRefs(child);
+      }
+    }
+    verifyNodeParentRefs(root5!);
   });
 
   test("handles streaming components", async () => {


### PR DESCRIPTION
The full graph is executed in parallel. This means that `addNode` calls don't necessarily occur in order, though usually they do. Luckily the context of the `parentId` is maintained correctly all the way through the execution tree.

The result is nodes that occassionally get dropped from the execution graph.

@danfhernandez was occasionally seeing instances where the first component was dropped from the checkpoint. I observed this once myself as well:

<img width="1482" alt="image" src="https://github.com/user-attachments/assets/be189cce-289a-4d49-bb66-463f7503280a" />

This change adds support for handling out of order insertion of nodes into the graph. If we try to insert a node with a parentId into the graph but the parent hasn't arrived yet, then we put it into an `orphaned` nodes list, and attempt to process it on subsequent `addNode` calls when other nodes arrive. In addition, we never write out a checkpoint when the tree is in an invalid state. 

I added tests that manually insert nodes into checkpoint manager to simulate multiple scenarios for out of order arrival to validate and lock in this behavior. 

