### PR TITLE
feat: adding support for generic arrays in gsx.array

### DIFF
--- a/packages/gensx/src/array.ts
+++ b/packages/gensx/src/array.ts
@@ -5,7 +5,7 @@ import { execute } from "./resolve";
 export class GsxArray<T> {
   private promise: Promise<unknown[]>;
 
-  constructor(items: JSX.Element[] | Promise<unknown[]>) {
+  constructor(items: JSX.Element[] | T[] | Promise<unknown[]>) {
     this.promise = Promise.resolve(items);
   }
 
@@ -63,6 +63,6 @@ export class GsxArray<T> {
   }
 }
 
-export function array<T>(items: JSX.Element[]): GsxArray<T> {
+export function array<T>(items: JSX.Element[] | T[]): GsxArray<T> {
   return new GsxArray(items);
 }

--- a/packages/gensx/tests/array.test.tsx
+++ b/packages/gensx/tests/array.test.tsx
@@ -157,3 +157,45 @@ test("can use gsx.array operations in child functions", async () => {
   // After filtering > 5 we get [6,8,10]
   expect(result).toEqual([6, 8, 10]);
 });
+
+test("map works with raw number arrays", async () => {
+  const arr = gsx.array<number>([1, 2, 3]);
+  const result = await arr.map(n => <NumberDoubler value={n} />).toArray();
+
+  expect(result).toEqual([2, 4, 6]);
+});
+
+test("filter works with raw number arrays", async () => {
+  const arr = gsx.array<number>([1, 2, 3, 4, 5, 6]);
+  const result = await arr
+    .filter(n => <AsyncNumberFilter value={n} />)
+    .toArray();
+
+  expect(result).toEqual([6]);
+});
+
+test("reduce works with raw number arrays", async () => {
+  const arr = gsx.array<number>([1, 2, 3]);
+  const result = await arr
+    .map<number>(n => <NumberDoubler value={n} />)
+    .reduce<number>((acc: number, n: number) => <Value value={acc + n} />, 0);
+
+  expect(result).toEqual(12); // (1*2 + 2*2 + 3*2)
+});
+
+test("flatMap works with raw number arrays", async () => {
+  const arr = gsx.array<number>([1, 2]);
+  const result = await arr.flatMap(n => <TaskGenerator value={n} />).toArray();
+
+  expect(result).toEqual([1, 2, 2, 4]);
+});
+
+test("chains multiple operations with raw arrays", async () => {
+  const arr = gsx.array<number>([1, 2, 3, 4, 5]);
+  const result = await arr
+    .map<number>(n => <NumberDoubler value={n} />)
+    .filter((n: number) => <AsyncNumberFilter value={n} />)
+    .reduce<number>((acc: number, n: number) => <Value value={acc + n} />, 0);
+
+  expect(result).toEqual(24); // (6 + 8 + 10) where all values > 5 are kept
+});


### PR DESCRIPTION
Fixes #171 

Adds support so that you can pass in objects like a `string[]` to `gsx.array()`